### PR TITLE
Move to scalar formulation + refactor dimensionless numbers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,16 +1,45 @@
-# Prerequisites
-*.d
+
+## do not want to track any makefiles on remote. 
+**/*.tst
+**/make*
+**/*.s*
+**/*.d*
+**/*.deps
+**/*.tags*
+
+
+
+# basililsk specific files
+**/*.DS_Store
+**/*.html
+**/intermediate*
+**/log*.dat
+**/restart*
+**/*.tags*
+**/*.deps
+**/*.tests
+**/*.s*
+**/Video
+**/*.mp4
+**/*.json
+**/*.bv
+**/*.png
+
+# Custom executables (add your specific executable names here)
+getFacet
+getData-elastic-scalar
+pizza
+
+# never exclude these files
+!*.c
+!*.h
+!*.sbatch
 
 # Object files
 *.o
 *.ko
 *.obj
 *.elf
-
-# Linker output
-*.ilk
-*.map
-*.exp
 
 # Precompiled Headers
 *.gch
@@ -50,3 +79,26 @@ modules.order
 Module.symvers
 Mkfile.old
 dkms.conf
+
+# IDE/Editor folders
+.vscode/
+.idea/
+*.swp
+*~
+
+# Build directories
+build/
+bin/
+obj/
+
+# Dependency directories
+deps/
+
+# OS generated files
+**/*.DS_Store
+**/.DS_Store?
+**/._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db

--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,7 @@
 **/*.mp4
 **/*.json
 **/*.bv
-**/*.png
+*/*.png
 
 # Custom executables (add your specific executable names here)
 getFacet

--- a/README.md
+++ b/README.md
@@ -1,2 +1,62 @@
 # Viscoelastic-pizza
- 
+
+## Background:
+
+The charateristic scales: $R_0$, $G$, $\rho$: initial radius of the blob, elastic (pizza) modulus, and (pizza) density.
+
+The characteristic frequency is $\Omega_c = \sqrt{G/(\rho R_0^2)}$: frequency required to significantly stretch the blob.
+
+For Oldroyd-B, the parameters are: 
+- Dimensionless retardation time: $t_{\eta s} = (\eta_s/G)*\Omega_c = \eta_s/\sqrt{\rho G R_0^2}$. $t_{\eta s}$ is the time it takes to show an elastic response
+  - For a purely elastic solid, $t_{\eta s}$ is 0
+  - $t_{\eta s} \to \infty$ is liquid. 
+
+- Dimensionless relaxation time: $t_\lambda = \lambda * \Omega_c = \lambda * \sqrt{G/(\rho R_0^2)}$. $t_\lambda$ is the time it takes to show a viscous response
+  - For a viscous liquid, $t_\lambda$ is 0 and for solids, $t_\lambda \to \infty$.
+  - A purely elastic solid has $t_{\eta s} = 0$ and $t_\lambda \to \infty$.
+
+### Additionally, there are two other dimensionless numbers:
+
+#### Pizza number: $\Pi = \rho\Omega^2R_0^2/G$.
+
+This is the ratio of inertial to elastic forces. This is the square of the ratio of two characteristic frequencies: $(\Omega/\Omega_c)^2$.<br>
+$\Pi \gg 1$ is needed to show significant deformation of the blob. This is similar to the Bond number.
+
+#### Elasto-capillary number: $Ec = \gamma/(G R_0)$.
+
+This compares the elastic to capillary forces. To start with, we can assume $G \gg \gamma/R$.
+- Another way to think about it is that $Ec = \Omega_\gamma^2/\Omega_c^2 = \frac{\gamma/(\rho R_0^3)}{G/(\rho R_0^2)} = \gamma/(G R_0)$.
+
+## Oldroyd-B model implementation
+For details of the constitutive model [Oldroyd-B model](https://en.wikipedia.org/wiki/Oldroyd-B_model), see: [https://github.com/comphy-lab/Viscoelastic3D](https://github.com/comphy-lab/Viscoelastic3D).
+
+
+## How to run the code:
+
+One core:
+
+```shell
+qcc -O2 -Wall -disable-dimensions pizza.c -o pizza -lm 
+./pizza
+```
+
+OpenMP parallelization:
+
+```shell 
+qcc -O2 -Wall -disable-dimensions pizza.c -o pizza -lm -fopenmp 
+export OMP_NUM_THREADS=16
+./pizza
+```
+Here, change 16 to the number of available threads. 
+
+OpenMPI parallelization:
+
+```shell
+CC99='mpicc -std=c99' qcc -Wall -O2 -D_MPI=1 -disable-dimensions pizza.c -o pizza -lm
+mpirun -np 16 ./pizza
+```
+Here, change 16 to the number of available cores. 
+
+
+**Note:** In the [pizza.c](pizza.c) file, you can uncomment and edit ``argv" parts to pass parameters from terminal. 
+

--- a/log-conform-Elastic_v9.h
+++ b/log-conform-Elastic_v9.h
@@ -1,8 +1,13 @@
-/** Title: log-conform-elastic_v5.h
+/** Title: log-conform-elastic_v9.h
 # Author: Vatsal Sanjay & Ayush Dixit
 # vatsalsanjay@gmail.com
 # Physics of Fluids
-# Updated: Aug 18, 2023
+# Updated: Nov 03, 2024
+
+# Changelog Nov 03, 2024: 
+- This is a legacy version and no longer in use.
+- The current version is [log-conform-viscoelastic-scalar-2D](log-conform-viscoelastic-scalar-2D). Please use that instead.
+- For details, see: [https://github.com/comphy-lab/Viscoelastic3D](https://github.com/comphy-lab/Viscoelastic3D)
 */
 
 // The code is same as http://basilisk.fr/src/log-conform.h but written for purely elastic limit (lambda \to \infty)

--- a/log-conform-viscoelastic-scalar-2D.h
+++ b/log-conform-viscoelastic-scalar-2D.h
@@ -174,7 +174,7 @@ TODO:
 scalar A11[], A12[], A22[]; // conformation tensor
 scalar T11[], T12[], T22[]; // stress tensor
 #if AXI
-scalar Aqq[], T_ThTh[];
+scalar AThTh[], T_ThTh[];
 #endif
 
 event defaults (i = 0) {

--- a/log-conform-viscoelastic-scalar-2D.h
+++ b/log-conform-viscoelastic-scalar-2D.h
@@ -1,0 +1,581 @@
+/** Title: log-conform-viscoelastic-2DNaxi.h
+# Version: 2.0
+# Main feature 1: A exists in across the domain and relaxes according to \lambda. The stress only acts according to G.
+# Main feature 2: This is the 2D+axi **scalar** implementation of https://github.com/VatsalSy/BurstingBubble_VE_coated/blob/main/log-conform-viscoelastic.h.
+
+# Author: Vatsal Sanjay
+# vatsalsanjay@gmail.com
+# Physics of Fluids
+# Updated: Nov 3, 2024
+
+# change log: Oct 18, 2024 (v1.0)
+- 2D+axi implementation
+- scalar implementation
+*/
+
+/** The code is same as http://basilisk.fr/src/log-conform.h but 
+- written with G-\lambda formulation. 
+- It also fixes the bug where [\sigma_p] = 0 & [\sigma_s] = \gamma\kappa instead of [\sigma_s+\sigma_p] = \gamma\kappa.
+
+# change log: Nov 3, 2024 (v2.0)
+- Added documentation and made the code an axi mirror version of [log-conform-viscoelastic-scalar-3D.h](log-conform-viscoelastic-scalar-3D.h).
+- v2.0 is documentation only change to keep version number in sync with [log-conform-viscoelastic-scalar-3D.h](log-conform-viscoelastic-scalar-3D.h).
+
+Other under the hood changes:
+- Added a check for negative eigenvalues. If any are found, print the location and value of the offending eigenvalue. Please report this bug by opening an issue on the GitHub repository. 
+- Added some initialization functions for pseudo_v and pseudo_t.
+
+
+*/ 
+
+/** The code is same as http://basilisk.fr/src/log-conform.h but 
+- written with G-\lambda formulation. 
+- It also fixes the bug where [\sigma_p] = 0 & [\sigma_s] = \gamma\kappa instead of [\sigma_s+\sigma_p] = \gamma\kappa.
+*/ 
+
+/**
+ * # TODO: (non-critical, non-urgent)
+ * Ideally, we would like to consistently use tensor formulation to leverage ease of readability and maintainability. Also, tensors will be more efficient and would avoid bugs. It is also a prerequisite for axi compatibility of the 3D version of this code: [log-conform-viscoelastic-scalar-3D.h](log-conform-viscoelastic-scalar-3D.h). See: https://github.com/comphy-lab/Viscoelastic3D/issues/11 and https://github.com/comphy-lab/Viscoelastic3D/issues/5. 
+ * - [ ] enfore all tensors and make the code generally compatible using foreach_dimensions
+*/
+
+/**
+# The log-conformation method for some viscoelastic constitutive models
+
+## Introduction
+
+Viscoelastic fluids exhibit both viscous and elastic behaviour when
+subjected to deformation. Therefore these materials are governed by
+the Navier--Stokes equations enriched with an extra *elastic* stress
+$Tij$
+$$
+\rho\left[\partial_t\mathbf{u}+\nabla\cdot(\mathbf{u}\otimes\mathbf{u})\right] = 
+- \nabla p + \nabla\cdot(2\mu_s\mathbf{D}) + \nabla\cdot\mathbf{T}
++ \rho\mathbf{a}
+$$
+where $\mathbf{D}=[\nabla\mathbf{u} + (\nabla\mathbf{u})^T]/2$ is the
+deformation tensor and $\mu_s$ is the solvent viscosity of the
+viscoelastic fluid.
+
+The *polymeric* stress $\mathbf{T}$ represents memory effects due to
+the polymers. Several constitutive rheological models are available in
+the literature where the polymeric stress $\mathbf{T}$ is typically a 
+function $\mathbf{f_s}(\cdot)$ of the conformation tensor $\mathbf{A}$ such as
+$$
+\mathbf{T} = G_p \mathbf{f_s}(\mathbf{A})
+$$
+where $G_p$ is the elastic modulus and $\mathbf{f_s}(\cdot)$ is the relaxation function.
+
+The conformation tensor $\mathbf{A}$ is related to the deformation of
+the polymer chains. $\mathbf{A}$ is governed by the equation
+$$
+D_t \mathbf{A} - \mathbf{A} \cdot \nabla \mathbf{u} - \nabla
+\mathbf{u}^{T} \cdot \mathbf{A} =
+-\frac{\mathbf{f_r}(\mathbf{A})}{\lambda} 
+$$
+where $D_t$ denotes the material derivative and
+$\mathbf{f_r}(\cdot)$ is the relaxation function. Here, $\lambda$ is the relaxation time.
+
+In the case of an Oldroyd-B viscoelastic fluid, $\mathbf{f}_s
+(\mathbf{A}) = \mathbf{f}_r (\mathbf{A}) = \mathbf{A} -\mathbf{I}$,
+and the above equations can be combined to avoid the use of
+$\mathbf{A}$
+$$
+\mathbf{T} + \lambda (D_t \mathbf{T} -
+\mathbf{T} \cdot \nabla \mathbf{u} -
+\nabla \mathbf{u}^{T} \cdot \mathbf{T})  = 2 G_p\lambda \mathbf{D}
+$$
+
+[Comminal et al. (2015)](#comminal2015) gathered the functions
+$\mathbf{f}_s (\mathbf{A})$ and $\mathbf{f}_r (\mathbf{A})$ for
+different constitutive models.
+
+## Parameters
+
+The primary parameters are the relaxation time
+$\lambda$ and the elastic modulus $G_p$. The solvent viscosity
+$\mu_s$ is defined in the [Navier-Stokes
+solver](navier-stokes/centered.h). 
+
+Gp and lambda are defined in [two-phaseVE.h](two-phaseVE.h).
+*/
+
+/**
+## The log conformation approach
+
+The numerical resolution of viscoelastic fluid problems often faces the
+[High-Weissenberg Number
+Problem](http://www.ma.huji.ac.il/~razk/iWeb/My_Site/Research_files/Visco1.pdf). 
+This is a numerical instability appearing when strongly elastic flows
+create regions of high stress and fine features. This instability
+poses practical limits to the values of the relaxation time of the
+viscoelastic fluid, $\lambda$.  [Fattal \& Kupferman (2004,
+2005)](#fattal2004) identified the exponential nature of the solution
+as the origin of the instability. They proposed to use the logarithm
+of the conformation tensor $\Psi = \log \, \mathbf{A}$ rather than the
+viscoelastic stress tensor to circumvent the instability.
+
+The constitutive equation for the log of the conformation tensor is
+$$ 
+D_t \Psi = (\Omega \cdot \Psi -\Psi \cdot \Omega) + 2 \mathbf{B} +
+\frac{e^{-\Psi} \mathbf{f}_r (e^{\Psi})}{\lambda}
+$$
+where $\Omega$ and $\mathbf{B}$ are tensors that result from the
+decomposition of the transpose of the tensor gradient of the
+velocity
+$$ 
+(\nabla \mathbf{u})^T = \Omega + \mathbf{B} + N
+\mathbf{A}^{-1} 
+$$ 
+
+The antisymmetric tensor $\Omega$ requires only the memory of a scalar
+in 2D since,
+$$ 
+\Omega = \left( 
+\begin{array}{cc}
+0 & \Omega_{12} \\
+-\Omega_{12} & 0
+\end{array} 
+\right)
+$$
+
+For 3D, $\Omega$ is a skew-symmetric tensor given by
+
+$$
+\Omega = \left( 
+\begin{array}{ccc}
+0 & \Omega_{12} & \Omega_{13} \\
+-\Omega_{12} & 0 & \Omega_{23} \\
+-\Omega_{13} & -\Omega_{23} & 0
+\end{array} 
+\right)
+$$
+
+The log-conformation tensor, $\Psi$, is related to the
+polymeric stress tensor $\mathbf{T}$, by the strain function 
+$\mathbf{f}_s (\mathbf{A})$
+$$ 
+\Psi = \log \, \mathbf{A} \quad \mathrm{and} \quad \mathbf{T} =
+\frac{G_p}{\lambda} \mathbf{f}_s (\mathbf{A})
+$$
+where $Tr$ denotes the trace of the tensor and $L$ is an additional
+property of the viscoelastic fluid.
+
+We will use the Bell--Collela--Glaz scheme to advect the log-conformation 
+tensor $\Psi$. */
+
+/*
+TODO: 
+- Perhaps, instead of the Bell--Collela--Glaz scheme, we can use the conservative form of the advection equation and transport the log-conformation tensor with the VoF color function, similar to [http://basilisk.fr/src/navier-stokes/conserving.h](http://basilisk.fr/src/navier-stokes/conserving.h)
+*/
+
+#include "bcg.h"
+
+scalar A11[], A12[], A22[]; // conformation tensor
+scalar T11[], T12[], T22[]; // stress tensor
+#if AXI
+scalar Aqq[], T_ThTh[];
+#endif
+
+event defaults (i = 0) {
+  if (is_constant (a.x))
+    a = new face vector;
+
+  /*
+  initialize A and T
+  */
+  for (scalar s in {A11, A22}) {
+    foreach () {
+      s[] = 1.;
+    }
+  }
+  for (scalar s in {T11, T12, T22, A12}) {
+    foreach(){
+      s[] = 0.;
+    }
+  }
+#if AXI
+  foreach(){
+    T_ThTh[] = 0;
+    AThTh[] = 1.;
+  }
+#endif
+
+  for (scalar s in {T11, T12, T22}) {
+    if (s.boundary[left] != periodic_bc) {
+        s[left] = neumann(0);
+	      s[right] = neumann(0);
+      }
+  }
+
+  for (scalar s in {A11, A12, A22}) {
+    if (s.boundary[left] != periodic_bc) {
+        s[left] = neumann(0);
+	      s[right] = neumann(0);
+    }
+  }
+
+#if AXI
+  T12[bottom] = dirichlet (0.);  
+  A12[bottom] = dirichlet (0.);  
+#endif
+}
+
+/**
+## Useful functions in 2D
+
+The first step is to implement a routine to calculate the eigenvalues
+and eigenvectors of the conformation tensor $\mathbf{A}$.
+
+These structs ressemble Basilisk vectors and tensors but are just
+arrays not related to the grid. */
+
+typedef struct { double x, y;}   pseudo_v;
+typedef struct { pseudo_v x, y;} pseudo_t;
+
+// Function to initialize pseudo_v
+static inline void init_pseudo_v(pseudo_v *v, double value) {
+    v->x = value;
+    v->y = value;
+}
+
+// Function to initialize pseudo_t
+static inline void init_pseudo_t(pseudo_t *t, double value) {
+    init_pseudo_v(&t->x, value);
+    init_pseudo_v(&t->y, value);
+}
+
+static void diagonalization_2D (pseudo_v * Lambda, pseudo_t * R, pseudo_t * A)
+{
+  /**
+  The eigenvalues are saved in vector $\Lambda$ computed from the
+  trace and the determinant of the symmetric conformation tensor
+  $\mathbf{A}$. */
+
+  if (sq(A->x.y) < 1e-15) {
+    R->x.x = R->y.y = 1.;
+    R->y.x = R->x.y = 0.;
+    Lambda->x = A->x.x; Lambda->y = A->y.y;
+    return;
+  }
+
+  double T = A->x.x + A->y.y; // Trace of the tensor
+  double D = A->x.x*A->y.y - sq(A->x.y); // Determinant
+
+  /**
+  The eigenvectors, $\mathbf{v}_i$ are saved by columns in tensor
+  $\mathbf{R} = (\mathbf{v}_1|\mathbf{v}_2)$. */
+
+  R->x.x = R->x.y = A->x.y;
+  R->y.x = R->y.y = -A->x.x;
+  double s = 1.;
+  for (int i = 0; i < dimension; i++) {
+    double * ev = (double *) Lambda;
+    ev[i] = T/2 + s*sqrt(sq(T)/4. - D);
+    s *= -1;
+    double * Rx = (double *) &R->x;
+    double * Ry = (double *) &R->y;
+    Ry[i] += ev[i];
+    double mod = sqrt(sq(Rx[i]) + sq(Ry[i]));
+    Rx[i] /= mod;
+    Ry[i] /= mod;
+  }
+}
+
+/**
+The stress tensor depends on previous instants and has to be
+integrated in time. In the log-conformation scheme the advection of
+the stress tensor is circumvented, instead the conformation tensor,
+$\mathbf{A}$ (or more precisely the related variable $\Psi$) is
+advanced in time.
+
+In what follows we will adopt a scheme similar to that of [Hao \& Pan
+(2007)](#hao2007). We use a split scheme, solving successively
+
+a) the upper convective term:
+$$
+\partial_t \Psi = 2 \mathbf{B} + (\Omega \cdot \Psi -\Psi \cdot \Omega)
+$$
+b) the advection term:
+$$
+\partial_t \Psi + \nabla \cdot (\Psi \mathbf{u}) = 0
+$$
+c) the model term (but set in terms of the conformation 
+tensor $\mathbf{A}$). In an Oldroyd-B viscoelastic fluid, the model is
+$$ 
+\partial_t \mathbf{A} = -\frac{\mathbf{f}_r (\mathbf{A})}{\lambda}
+$$
+*/
+
+event tracer_advection(i++)
+{
+  scalar Psi11 = A11;
+  scalar Psi12 = A12;
+  scalar Psi22 = A22;
+#if AXI
+  scalar Psiqq = AThTh;
+#endif
+
+  /**
+  ### Computation of $\Psi = \log \mathbf{A}$ and upper convective term */
+
+  foreach() {
+    /**
+      We assume that the stress tensor $\mathbf{\tau}_p$ depends on the
+      conformation tensor $\mathbf{A}$ as follows
+      $$
+      \mathbf{\tau}_p = G_p (\mathbf{A}) =
+      G_p (\mathbf{A} - I)
+      $$
+    */
+
+    pseudo_t A;
+
+    A.x.x = A11[]; A.y.y = A22[];
+    A.x.y = A12[];
+
+#if AXI
+    double Aqq = AThTh[]; 
+    Psiqq[] = log (Aqq); 
+#endif
+
+    /**
+    The conformation tensor is diagonalized through the
+    eigenvector tensor $\mathbf{R}$ and the eigenvalues diagonal
+    tensor, $\Lambda$. */
+
+    pseudo_v Lambda;
+    init_pseudo_v(&Lambda, 0.0); 
+    pseudo_t R;
+    init_pseudo_t(&R, 0.0);
+    diagonalization_2D (&Lambda, &R, &A);
+
+    /*
+    Check for negative eigenvalues -- this should never happen. If it does, print the location and value of the offending eigenvalue.
+    Please report this bug by opening an issue on the GitHub repository. 
+    */
+    if (Lambda.x <= 0. || Lambda.y <= 0.) {
+      fprintf(ferr, "Negative eigenvalue detected: Lambda.x = %g, Lambda.y = %g\n", Lambda.x, Lambda.y);
+      fprintf(ferr, "x = %g, y = %g, f = %g\n", x, y, f[]);
+      exit(1);
+    }
+    
+    /**
+    $\Psi = \log \mathbf{A}$ is easily obtained after diagonalization, 
+    $\Psi = R \cdot \log(\Lambda) \cdot R^T$. */
+    
+    Psi12[] = R.x.x*R.y.x*log(Lambda.x) + R.y.y*R.x.y*log(Lambda.y);
+    Psi11[] = sq(R.x.x)*log(Lambda.x) + sq(R.x.y)*log(Lambda.y);
+    Psi22[] = sq(R.y.y)*log(Lambda.y) + sq(R.y.x)*log(Lambda.x);
+
+    /**
+    We now compute the upper convective term $2 \mathbf{B} +
+    (\Omega \cdot \Psi -\Psi \cdot \Omega)$.
+
+    The diagonalization will be applied to the velocity gradient
+    $(\nabla u)^T$ to obtain the antisymmetric tensor $\Omega$ and
+    the traceless, symmetric tensor, $\mathbf{B}$. If the conformation
+    tensor is $\mathbf{I}$, $\Omega = 0$ and $\mathbf{B}= \mathbf{D}$.  
+
+    Otherwise, compute M = R * (nablaU)^T * R^T, where nablaU is the velocity gradient tensor. Then, 
+    
+    1. Calculate omega using the off-diagonal elements of M and eigenvalues:
+       omega = (Lambda.y*M.x.y + Lambda.x*M.y.x)/(Lambda.y - Lambda.x)
+       This represents the rotation rate in the eigenvector basis.
+    
+    2. Transform omega back to physical space to get OM:
+       OM = (R.x.x*R.y.y - R.x.y*R.y.x)*omega
+       This gives us the rotation tensor Omega in the original coordinate system.
+    
+    3. Compute B tensor components using M and R: B is related to M and R through:
+       
+       In 2D:
+       $$
+       B_{xx} = R_{xx}^2 M_{xx} + R_{xy}^2 M_{yy} \\
+       B_{xy} = R_{xx}R_{yx} M_{xx} + R_{xy}R_{yy} M_{yy} \\
+       B_{yx} = B_{xy} \\
+       B_{yy} = -B_{xx}
+       $$
+       
+       Where:
+       - R is the eigenvector matrix of the conformation tensor
+       - M is the velocity gradient tensor in the eigenvector basis
+       - The construction ensures B is symmetric and traceless
+    */
+
+    pseudo_t B;
+    init_pseudo_t(&B, 0.0);
+    double OM = 0.;
+    if (fabs(Lambda.x - Lambda.y) <= 1e-20) {
+      B.x.y = (u.y[1,0] - u.y[-1,0] + u.x[0,1] - u.x[0,-1])/(4.*Delta); 
+      foreach_dimension() 
+        B.x.x = (u.x[1,0] - u.x[-1,0])/(2.*Delta);
+    } else {
+      pseudo_t M;
+      init_pseudo_t(&M, 0.0);
+      foreach_dimension() {
+        M.x.x = (sq(R.x.x)*(u.x[1] - u.x[-1]) +
+        sq(R.y.x)*(u.y[0,1] - u.y[0,-1]) +
+        R.x.x*R.y.x*(u.x[0,1] - u.x[0,-1] + 
+        u.y[1] - u.y[-1]))/(2.*Delta);
+        M.x.y = (R.x.x*R.x.y*(u.x[1] - u.x[-1]) + 
+        R.x.y*R.y.x*(u.y[1] - u.y[-1]) +
+        R.x.x*R.y.y*(u.x[0,1] - u.x[0,-1]) +
+        R.y.x*R.y.y*(u.y[0,1] - u.y[0,-1]))/(2.*Delta);
+      }
+      double omega = (Lambda.y*M.x.y + Lambda.x*M.y.x)/(Lambda.y - Lambda.x);
+      OM = (R.x.x*R.y.y - R.x.y*R.y.x)*omega;
+
+      B.x.y = M.x.x*R.x.x*R.y.x + M.y.y*R.y.y*R.x.y;
+      foreach_dimension()
+        B.x.x = M.x.x*sq(R.x.x)+M.y.y*sq(R.x.y);	
+    }
+
+    /**
+    We now advance $\Psi$ in time, adding the upper convective
+    contribution. */
+
+    double s = -Psi12[];
+    Psi12[] += dt * (2. * B.x.y + OM * (Psi22[] - Psi11[]));
+    s *= -1;
+    Psi11[] += dt * 2. * (B.x.x + s * OM);
+    s *= -1;
+    Psi22[] += dt * 2. * (B.y.y + s * OM);
+
+    /**
+    In the axisymmetric case, the governing equation for $\Psi_{\theta
+    \theta}$ only involves that component, 
+    $$ 
+    \Psi_{\theta \theta}|_t - 2 L_{\theta \theta} = 
+    \frac{\mathbf{f}_r(e^{-\Psi_{\theta \theta}})}{\lambda} 
+    $$
+    with $L_{\theta \theta} = u_y/y$. Therefore step (a) for
+    $\Psi_{\theta \theta}$ is */
+
+#if AXI
+    Psiqq[] += dt*2.*u.y[]/max(y, 1e-20);
+#endif
+  }
+
+  /**
+  ### Advection of $\Psi$
+  
+  We proceed with step (b), the advection of the log of the
+  conformation tensor $\Psi$. */
+
+#if AXI
+  advection ({Psi11, Psi12, Psi22, Psiqq}, uf, dt);
+#else
+  advection ({Psi11, Psi12, Psi22}, uf, dt);
+#endif
+
+  /**
+  ### Convert back to Aij */
+
+  foreach() {
+    /**
+    It is time to undo the log-conformation, again by
+    diagonalization, to recover the conformation tensor $\mathbf{A}$
+    and to perform step (c).*/
+
+    pseudo_t A = {{Psi11[], Psi12[]}, {Psi12[], Psi22[]}}, R;
+    init_pseudo_t(&R, 0.0);
+    pseudo_v Lambda;
+    init_pseudo_v(&Lambda, 0.0);
+    diagonalization_2D (&Lambda, &R, &A);
+    Lambda.x = exp(Lambda.x), Lambda.y = exp(Lambda.y);
+    
+    A.x.y = R.x.x*R.y.x*Lambda.x + R.y.y*R.x.y*Lambda.y;
+    foreach_dimension()
+      A.x.x = sq(R.x.x)*Lambda.x + sq(R.x.y)*Lambda.y;
+#if AXI
+      double Aqq = exp(Psiqq[]);
+#endif
+
+    /**
+    We perform now step (c) by integrating 
+    $\mathbf{A}_t = -\mathbf{f}_r (\mathbf{A})/\lambda$ to obtain
+    $\mathbf{A}^{n+1}$. This step is analytic,
+    $$
+    \int_{t^n}^{t^{n+1}}\frac{d \mathbf{A}}{\mathbf{I}- \mathbf{A}} = 
+    \frac{\Delta t}{\lambda}
+    $$
+    */
+
+    double intFactor = lambda[] != 0. ? exp(-dt/lambda[]): 0.;
+     
+#if AXI
+      Aqq = (1. - intFactor) + intFactor*exp(Psiqq[]);
+#endif
+
+    A.x.y *= intFactor;
+    foreach_dimension()
+      A.x.x = (1. - intFactor) + A.x.x*intFactor;
+
+    /**
+      Then the Conformation tensor $\mathcal{A}_p^{n+1}$ is restored from
+      $\mathbf{A}^{n+1}$.  */
+    
+    A12[] = A.x.y;
+    T12[] = Gp[]*A.x.y;
+#if AXI
+      AThTh[] = Aqq;
+      T_ThTh[] = Gp[]*(Aqq - 1.);
+#endif
+
+    A11[] = A.x.x;
+    T11[] = Gp[]*(A.x.x - 1.);
+    A22[] = A.y.y;
+    T22[] = Gp[]*(A.y.y - 1.);
+  }
+}
+
+/**
+### Divergence of the viscoelastic stress tensor
+
+The viscoelastic stress tensor $\mathbf{\tau}_p$ is defined at cell centers
+while the corresponding force (acceleration) will be defined at cell
+faces. Two terms contribute to each component of the momentum
+equation. For example the $x$-component in Cartesian coordinates has
+the following terms: $\partial_x \mathbf{\tau}_{p_{xx}} + \partial_y
+\mathbf{\tau}_{p_{xy}}$. The first term is easy to compute since it can be
+calculated directly from center values of cells sharing the face. The
+other one is harder. It will be computed from vertex values. The
+vertex values are obtained by averaging centered values.  Note that as
+a result of the vertex averaging cells `[]` and `[-1,0]` are not
+involved in the computation of shear. */
+
+event acceleration (i++)
+{
+  face vector av = a;
+
+  foreach_face(x){
+    if (fm.x[] > 1e-20) {
+      
+      double shearX = (T12[0,1]*cm[0,1] + T12[-1,1]*cm[-1,1] - 
+      T12[0,-1]*cm[0,-1] - T12[-1,-1]*cm[-1,-1])/4.;
+      
+      av.x[] += (shearX + cm[]*T11[] - cm[-1]*T11[-1])*
+      alpha.x[]/(sq(fm.x[])*Delta);
+    
+    }
+  }
+
+  foreach_face(y){
+    if (fm.y[] > 1e-20) {
+
+      double shearY = (T12[1,0]*cm[1,0] + T12[1,-1]*cm[1,-1] - 
+      T12[-1,0]*cm[-1,0] - T12[-1,-1]*cm[-1,-1])/4.;
+      
+      av.y[] += (shearY + cm[]*T22[] - cm[0,-1]*T22[0,-1])*
+      alpha.y[]/(sq(fm.y[])*Delta);
+
+    }
+  }
+
+#if AXI
+  foreach_face(y)
+    if (y > 1e-20)
+      av.y[] -= (T_ThTh[] + T_ThTh[0,-1])*alpha.y[]/sq(y)/2.;
+#endif
+}

--- a/pizza.c
+++ b/pizza.c
@@ -40,22 +40,33 @@ u.n[right] = neumann(0.);
 p[right] = dirichlet(0.);
 
 /*
-The charateristic scales: R_0, G, \rho: initial radius of the blob, elastic (pizza) modulus, and (pizza) density.
-The characteristic frequency is \Omega_c = sqrt{G/(\rho R_0^2)}: frequency required to significantly stretch the blob.
+The charateristic scales: $R_0$, $G$, $\rho$: initial radius of the blob, elastic (pizza) modulus, and (pizza) density.
+
+The characteristic frequency is $\Omega_c = \sqrt{G/(\rho R_0^2)}$: frequency required to significantly stretch the blob.
 
 For Oldroyd-B, the parameters are: 
-- Dimensionless retardation time: tEtas = (\eta_s/G)*\Omega_c = \eta_s/sqrt{\rho G R_0^2}. For a purely elastic solid, tR is 0 and tR \to \infty is liquid (tR is the time it takes to show an elastic response). 
-- Dimensionless relaxation time: tLam = \lambda * \Omega_c = \lambda * sqrt{G/(\rho R_0^2)}. For a purely viscous liquid, tLam is 0 and tLam \to \infty is solid (tLam is the time it takes to show a viscous response).
-* A purely elastic solid has tEtas = 0 and tLam = \infty.
+- Dimensionless retardation time: $t_{\eta s} = (\eta_s/G)*\Omega_c = \eta_s/\sqrt{\rho G R_0^2}$. $t_{\eta s}$ is the time it takes to show an elastic response
+  - For a purely elastic solid, $t_{\eta s}$ is 0
+  - $t_{\eta s} \to \infty$ is liquid. 
 
-Additionally, there are two other dimensionless numbers:
+- Dimensionless relaxation time: $t_\lambda = \lambda * \Omega_c = \lambda * \sqrt{G/(\rho R_0^2)}$. $t_\lambda$ is the time it takes to show a viscous response
+  - For a viscous liquid, $t_\lambda$ is 0 and for solids, $t_\lambda \to \infty$.
+  - A purely elastic solid has $t_{\eta s} = 0$ and $t_\lambda \to \infty$.
 
-# Pizza number: \Pi = \rho\Omega^2R_0^2/G.
-This is the ratio of inertial to elastic forces. This is the square of the ratio of two characteristic frequencies: (\Omega/\Omega_c)^2. \Pi \gg 1 is needed to show significant deformation of the blob. This is similar to the Bond number.
+### Additionally, there are two other dimensionless numbers:
 
-# Elasto-capillary number: Ec = \gamma/(G R_0).
-This compares the elastic to capillary forces. To start with, we can assume G \gg \gamma/R.
-- Another way to think about it is that Ec = \Omega_\gamma^2/(\Omega_c^2) = \frac{\gamma/(\rho R_0^3)}{G/(\rho R_0^2)} = \gamma/(G R_0).
+#### Pizza number: $\Pi = \rho\Omega^2R_0^2/G$.
+
+This is the ratio of inertial to elastic forces. This is the square of the ratio of two characteristic frequencies: $(\Omega/\Omega_c)^2$.<br>
+$\Pi \gg 1$ is needed to show significant deformation of the blob. This is similar to the Bond number.
+
+#### Elasto-capillary number: $Ec = \gamma/(G R_0)$.
+
+This compares the elastic to capillary forces. To start with, we can assume $G \gg \gamma/R$.
+- Another way to think about it is that $Ec = \Omega_\gamma^2/\Omega_c^2 = \frac{\gamma/(\rho R_0^3)}{G/(\rho R_0^2)} = \gamma/(G R_0)$.
+
+## Oldroyd-B model implementation
+For details of the constitutive model [Oldroyd-B model](https://en.wikipedia.org/wiki/Oldroyd-B_model), see: [https://github.com/comphy-lab/Viscoelastic3D](https://github.com/comphy-lab/Viscoelastic3D).
 */
 
 char comm[80], restartFile[80], logFile[80];

--- a/pizza.c
+++ b/pizza.c
@@ -1,67 +1,135 @@
-/** Title: Encapsulation
+/** Title: Elastic Pizza
+# Version: 2.0
+# Updated: Nov 03, 2024
+
 # Author: Vatsal Sanjay
 # vatsalsanjay@gmail.com
 # Physics of Fluids
-# Updated: Jan 07, 2021
+
+# Main feature: 
+- 2D+axi viscoelastic scalar implementation of the pizza problem.
+- There is no surface tension (infinite Weber number).
 */
 
-// 1 is Si Pool, 2 is Water Drop and 3 is air
+// 1 is Pizza and 2 is air
 #include "axi.h"
 #include "navier-stokes/centered.h"
 #define FILTERED
-#include "two-phase.h"
+#include "two-phaseVE.h"
 #include "navier-stokes/conserving.h"
-#include "log-conform-Elastic_v9.h"
-// #include "tension.h"
+#include "log-conform-viscoelastic-scalar-2D.h"
+#include "tension.h" // uncomment to make Weber number finite
 
 #define tsnap (1e-1)
 #define tsnap2 (1e-4)
-#define R0 (1e0)
-#define h0 (1e0)
 
 // error tolerances
 #define fErr (1e-3)
 #define VelErr (1e-3)
 #define KErr (1e-3)
+#define AErr (1e-3)
 
-double tmax, Ldomain, Omega, El, Re, We, MuAirPizza, RhoR;
+double tmax, Ldomain, Pi, tEtas, tLam, Ec, MuAirPizza, RhoR, H0;
 int MAXlevel;
-scalar Gpd[];
 
-// u.n[top] = neumann(0.);
-// p[top] = dirichlet(0.);
+// top is outflow
+u.n[top] = neumann(0.);
+p[top] = dirichlet(0.);
+// right is outflow
+u.n[right] = neumann(0.);
+p[right] = dirichlet(0.);
 
+/*
+The charateristic scales: R_0, G, \rho: initial radius of the blob, elastic (pizza) modulus, and (pizza) density.
+The characteristic frequency is \Omega_c = sqrt{G/(\rho R_0^2)}: frequency required to significantly stretch the blob.
+
+For Oldroyd-B, the parameters are: 
+- Dimensionless retardation time: tEtas = (\eta_s/G)*\Omega_c = \eta_s/sqrt{\rho G R_0^2}. For a purely elastic solid, tR is 0 and tR \to \infty is liquid (tR is the time it takes to show an elastic response). 
+- Dimensionless relaxation time: tLam = \lambda * \Omega_c = \lambda * sqrt{G/(\rho R_0^2)}. For a purely viscous liquid, tLam is 0 and tLam \to \infty is solid (tLam is the time it takes to show a viscous response).
+* A purely elastic solid has tEtas = 0 and tLam = \infty.
+
+Additionally, there are two other dimensionless numbers:
+
+# Pizza number: \Pi = \rho\Omega^2R_0^2/G.
+This is the ratio of inertial to elastic forces. This is the square of the ratio of two characteristic frequencies: (\Omega/\Omega_c)^2. \Pi \gg 1 is needed to show significant deformation of the blob. This is similar to the Bond number.
+
+# Elasto-capillary number: Ec = \gamma/(G R_0).
+This compares the elastic to capillary forces. To start with, we can assume G \gg \gamma/R.
+- Another way to think about it is that Ec = \Omega_\gamma^2/(\Omega_c^2) = \frac{\gamma/(\rho R_0^3)}{G/(\rho R_0^2)} = \gamma/(G R_0).
+*/
+
+char comm[80], restartFile[80], logFile[80];
 int main(int argc, char const *argv[]) {
   
   MAXlevel = 10;
   tmax = 4e0; //atof(argv[3]);
   Ldomain = 6.0; //atof(argv[4]);
 
-  Omega = 1e0; // it is the repeating variable
+  /*
+  Aspect ratio: H0/R. This is the initial height of the blob that will be stretched.
+  */
+  H0 = 1e0; // atof(argv[5]);
 
-  El = 1e-1; // G/\rho\Omega^2R^2
-  Re = 1e1; // \rho\OmegaR^2/\mu
-  We = 1e30; // \rho\Omega^2R^3/\gamma
-  MuAirPizza = 1e-3; // viscosity ratio \mu_{air}/\mu_{pizza dough}
-  RhoR = 1e-2; // density ratio \rho_{air}/\rho_{pizza dough}
+  /*
+  Pizza number: \rho\Omega^2R^2/G. 
+  */
+  Pi = 1e-1; // atof(argv[6]); 
+
+  /* 
+  Dimensionless retardation time: tEtas = (\eta_s/G)*\omega_c. For purely elastic solid, we need to keep tEas \to 0.  
+  */
+  tEtas = 1e-2; // atof(argv[7]); 
+  /*
+  Dimensionless relaxation time: tLam = \lambda * \omega_c. For purely elastic solid, we need to keep tLam \to \infty.
+  */
+  tLam = 1e30; // atof(argv[8]);   
+  /*
+  Elasto-capillary number: \gamma/(G R_0). For now, this value is only a placeholder. We will assume G \gg \gamma/R.
+  */
+  Ec = 1e-6; // atof(argv[9]); 
+
+  MuAirPizza = 1e-2; // atof(argv[10]); // viscosity ratio \mu_{air}/\mu_{pizza dough}. This value needs to be close to 0. 
+  RhoR = 1e-2; // atof(argv[11]); // density ratio \rho_{air}/\rho_{pizza dough}. This value needs to be very close to 0.
 
 
   L0=Ldomain;
-  X0=0.0; Y0=0.;
+  X0=0.; Y0=0.;
   init_grid (1 << (6));
 
-  char comm[80];
+  /*
+  In the folder called "intermediate", we will store the snapshot files as the simulation progresses. See event: writingFiles.
+  */
   sprintf (comm, "mkdir -p intermediate");
   system(comm);
+  /*
+  We save the restart file every t = tsnap such that if the simulation is interrupted, we can recover from the last saved state.
+  */
+  sprintf (restartFile, "restart");
+  /*
+  We also save the log file every few time steps.
+  */
+  sprintf (logFile, "logFile.dat");
 
-  rho1 = 1.000; mu1 = 1e0/Re;
-  rho2 = RhoR; mu2 = MuAirPizza/Re;
-  // polymers
-  Gp = Gpd;
 
-  // f.sigma = 1e0/We;
+  /*
+  Pizza */
+  rho1 = 1.000; mu1 = tEtas;
+  G1 = 1e0; 
+  lambda1 = tLam; // infinite relaxation time: phase 1 is Kelvin--Voigt solid.
+  /*
+  Air */
+  rho2 = RhoR; mu2 = MuAirPizza*mu1;
+  G2 = 0.; lambda2 = 0.; // air is modeled as purely Newtonian. 
+  /*
+  Surface tension
+  */
+  f.sigma = Ec;
 
-  fprintf(ferr, "Level %d tmax %g, El %g, Re %g, De Infty, We Infty\n", MAXlevel, tmax, El, Re);
+  // CFL and tolerance
+  CFL = 1e-2;
+  TOLERANCE = 1e-4;
+
+  fprintf(ferr, "Level %d tmax %g, Pi %g, tEtas %g, tLam %g, Ec %g\n", MAXlevel, tmax, Pi, tEtas, tLam, Ec);
   run();
 }
 
@@ -69,72 +137,99 @@ event acceleration (i++) {
   face vector av = a;
   foreach_face(y){
     double ff = (f[] + f[0,-1])/2.;
-    if (y > 0.)
-      av.y[] += ff*fm.y[]*sq(Omega);
-  }
-}
-
-event properties (i++) {
-  foreach () {
-   Gpd[] = El*clamp(f[], 0., 1.); // (f[] > 1.-1e-6 ? El: 0.); //// this is an artificial patch for now. The code has issues with VE terms in the interfacial cells!
-  //  lambdad[] = De*clamp(f[], 0., 1.); //f[] > 1.-1e-6 ? De: 0.); //De*clamp(f[], 0., 1.);
+    av.y[] += ff*fm.y[]*Pi;
   }
 }
 
 event init(t = 0){
-  if(!restore (file = "dump")){
+  if(!restore (file = restartFile)){
     /**
-    We can now initialize the volume fractions in the domain. */
-    refine(sq(x)/h0 + sq(y) < 1.05*R0 && sq(x)/h0 + sq(y) > 0.95*R0 && level<MAXlevel);
-    fraction(f, R0-(sq(x)/h0 + sq(y)));
-    // refine(x<(h0/2.0)+0.025 && y < 1e0+(h0/2.0)+0.025 && level<MAXlevel);
-    // fraction(f, y < 1e0+(h0/2.0) ? sq(h0/2.0)-(sq(x)+sq(y-(h0/2.0)-1e0)) : (h0/2.0)-x);
+    We can now initialize the volume fractions in the domain. 
+    For sqrt(sq(x/H0) + sq(y)) < 1, f = 1.
+    For sqrt(sq(x/H0) + sq(y)) > 1, f = 0.
+    */
+    // refine the interface region
+    refine(sq(x/H0) + sq(y) < sq(1.05) && sq(x/H0) + sq(y) > sq(0.95) && level<MAXlevel);
+    // define the volume fraction: VoF color function is continuous across the interface.
+    fraction(f, 1e0-sqrt(sq(x/H0) + sq(y)));
   }
-  // mask (x > 10.0 ? right : none);
 }
 
 event adapt(i++) {
-  adapt_wavelet ((scalar *){f, u.x, u.y},
-    (double[]){fErr, VelErr, VelErr},
-    MAXlevel, MAXlevel-4);
+  /*
+  We adapt the grid to resolve the interface and the flow. For infinite Weber number, these should be fine. 
+  For finite Weber number, perhaps adaptation based on curvature is also needed. 
+  */
+  adapt_wavelet ((scalar *){f, u.x, u.y, A11, A12, A22},
+    (double[]){fErr, VelErr, VelErr, AErr, AErr, AErr},
+    MAXlevel, 4);
 }
 
 // Outputs
 event writingFiles (t = 0; t += tsnap; t <= tmax + tsnap) {
-  dump (file = "dump");
+  dump (file = restartFile);
   char nameOut[80];
   sprintf (nameOut, "intermediate/snapshot-%5.4f", t);
   dump (file = nameOut);
 }
 
 event logWriting (i++) {
-  
+
   double ke = 0.;
   foreach (reduction(+:ke)){
-    ke += sq(Delta)*(sq(u.y[])+sq(u.x[]))*f[];
+    ke += 0.5*(2*pi*y)*rho(f[])*(sq(u.y[])+sq(u.x[]))*sq(Delta);
   }
+
+  scalar pos[];
+  position (f, pos, {0,1,0});
+  double rmax = statsf(pos).max;
+
+  if (pid() == 0){
+    static FILE * fp;
+    if (i == 0) {
+      fprintf (ferr, "i dt t ke rmax\n");
+      fp = fopen (logFile, "w");
+      fprintf(fp, "Level %d tmax %g, Pi %g, tEtas %g, tLam %g, Ec %g\n", MAXlevel, tmax, Pi, tEtas, tLam, Ec);
+      fprintf (fp, "i dt t ke rmax\n");
+    } else {
+      fp = fopen (logFile, "a");
+    }
+
+    fprintf (fp, "%d %g %g %g %g\n", i, dt, t, ke, rmax);
+    fclose(fp);
+    fprintf (ferr, "%d %g %g %g %g\n", i, dt, t, ke, rmax);
+    
+    if (ke < -1e-10){
+      dump(file="FailedDumpKeNegative");
+      fprintf(ferr, "Something very bad is happening! Stopping!\n");
+      return 1;
+    }
+    if (ke < 1e-10 && i > 100){
+      dump(file="StoppedDump");
+      fprintf(ferr, "kinetic energy too small now! Stopping!\n");
+      fp = fopen (logFile, "a");
+      fprintf(fp, "kinetic energy too small now! Stopping!\n");
+      fclose(fp);
+      return 1;
+    }
+    if (ke > 1e4){
+      dump(file="FailedDump");
+      fprintf(ferr, "kinetic energy blew up! Stopping!\n");
+      fp = fopen (logFile, "a");
+      fprintf(fp, "kinetic energy too small now! Stopping!\n");
+      fclose(fp);
+      return 1;
+    }
+  }
+
+}
+
+event end (t = tmax + tsnap) {
+  dump(file="FinalDump");
 
   static FILE * fp;
-  if (i == 0) {
-    fprintf (ferr, "i dt t ke\n");
-    fp = fopen ("log", "w");
-    fprintf(fp, "Level %d tmax %g, El %g, Re %g, De Infty, We Infty\n", MAXlevel, tmax, El, Re);
-    fprintf (fp, "i dt t ke\n");
-  } else {
-    fp = fopen ("log", "a");
-  }
-
-  fprintf (fp, "%d %g %g %g\n", i, dt, t, ke);
+  fp = fopen (logFile, "a");
+  fprintf(fp, "Level %d tmax %g, Pi %g, tEtas %g, tLam %g, Ec %g\n", MAXlevel, tmax, Pi, tEtas, tLam, Ec);
+  fprintf(fp, "End of simulation.\n");
   fclose(fp);
-  fprintf (ferr, "%d %g %g %g\n", i, dt, t, ke);
-  assert(ke > -1e-10);
-  // dump (file = "dump");
-  if (ke < 1e-6 && i > 100){
-    fprintf(ferr, "kinetic energy too small now! Stopping!\n");
-    fp = fopen ("log", "a");
-    fprintf(fp, "kinetic energy too small now! Stopping!\n");
-    fclose(fp);
-    return 1;
-  }
-
 }

--- a/two-phaseVE.h
+++ b/two-phaseVE.h
@@ -1,0 +1,139 @@
+/**
+ * Modification by Vatsal Sanjay 
+ * Version 2.0, Oct 17, 2024
+
+# Changelog
+- Oct 17, 2024: added support for VE simulations.
+
+# Brief history
+- v1.0 is the vanilla Basilisk code for two-phase flows: http://basilisk.fr/src/two-phase.h + http://basilisk.fr/src/two-phase-generic.h
+- v2.0 is the modification for viscoelastic fluids using the log-conformation method.
+
+# Two-phase interfacial flows
+This is a modified version of [two-phase.h](http://basilisk.fr/src/two-phase.h). It contains the implementation of
+Viscoplastic Fluid (Bingham Fluid).<br/>
+This file helps setup simulations for flows of two fluids separated by
+an interface (i.e. immiscible fluids). It is typically used in
+combination with a [Navier--Stokes solver](navier-stokes/centered.h).
+
+The interface between the fluids is tracked with a Volume-Of-Fluid
+method. The volume fraction in fluid 1 is $f=1$ and $f=0$ in fluid
+2. The densities and dynamic viscosities for fluid 1 and 2 are *rho1*,
+*mu1*, *rho2*, *mu2*, respectively. */
+
+#include "vof.h"
+
+scalar f[], * interfaces = {f};
+(const) scalar Gp = unity; // elastic modulus
+(const) scalar lambda = unity; // relaxation time
+
+double rho1 = 1., mu1 = 0., rho2 = 1., mu2 = 0.;
+double G1 = 0., G2 = 0.; // elastic moduli
+double lambda1 = 0., lambda2 = 0.; // relaxation times
+double TOLelastic = 1e-2; // tolerance for elastic modulus #TOFIX: this must always be a very small number.
+
+/**
+Auxilliary fields are necessary to define the (variable) specific
+volume $\alpha=1/\rho$ as well as the cell-centered density. */
+
+face vector alphav[];
+scalar rhov[];
+scalar Gpd[];
+scalar lambdapd[];
+
+event defaults (i = 0) {
+  alpha = alphav;
+  rho = rhov;
+  Gp = Gpd;
+  lambda = lambdapd;
+
+  /**
+  If the viscosity is non-zero, we need to allocate the face-centered
+  viscosity field. */
+
+  mu = new face vector;
+}
+
+/**
+The density and viscosity are defined using arithmetic averages by
+default. The user can overload these definitions to use other types of
+averages (i.e. harmonic). */
+
+#ifndef rho
+# define rho(f) (clamp(f,0.,1.)*(rho1 - rho2) + rho2)
+#endif
+#ifndef mu
+// for Arithmetic mean, use this
+# define mu(f)  (clamp(f,0.,1.)*(mu1 - mu2) + mu2)
+#endif
+
+/**
+We have the option of using some "smearing" of the density/viscosity
+jump. */
+
+#ifdef FILTERED
+scalar sf[];
+#else
+# define sf f
+#endif
+
+event tracer_advection (i++) {
+
+  /**
+  When using smearing of the density jump, we initialise *sf* with the
+  vertex-average of *f*. */
+
+#ifndef sf
+#if dimension <= 2
+  foreach()
+    sf[] = (4.*f[] +
+	    2.*(f[0,1] + f[0,-1] + f[1,0] + f[-1,0]) +
+	    f[-1,-1] + f[1,-1] + f[1,1] + f[-1,1])/16.;
+#else // dimension == 3
+  foreach()
+    sf[] = (8.*f[] +
+	    4.*(f[-1] + f[1] + f[0,1] + f[0,-1] + f[0,0,1] + f[0,0,-1]) +
+	    2.*(f[-1,1] + f[-1,0,1] + f[-1,0,-1] + f[-1,-1] +
+		f[0,1,1] + f[0,1,-1] + f[0,-1,1] + f[0,-1,-1] +
+		f[1,1] + f[1,0,1] + f[1,-1] + f[1,0,-1]) +
+	    f[1,-1,1] + f[-1,1,1] + f[-1,1,-1] + f[1,1,1] +
+	    f[1,1,-1] + f[-1,-1,-1] + f[1,-1,-1] + f[-1,-1,1])/64.;
+#endif
+#endif
+
+#if TREE
+  sf.prolongation = refine_bilinear;
+  sf.dirty = true; // boundary conditions need to be updated
+#endif
+}
+
+event properties (i++) {
+  
+  foreach_face() {
+    double ff = (sf[] + sf[-1])/2.;
+    alphav.x[] = fm.x[]/rho(ff);
+    face vector muv = mu;
+    muv.x[] = fm.x[]*mu(ff);
+  }
+
+  foreach(){
+    rhov[] = cm[]*rho(sf[]);
+
+    Gpd[] = 0.;
+    lambdapd[] = 0.;
+
+    if (clamp(sf[], 0., 1.) > TOLelastic){
+      Gpd[] += G1*clamp(sf[], 0., 1.);
+      lambdapd[] += lambda1*clamp(sf[], 0., 1.);
+    }
+    if (clamp((1-sf[]), 0., 1.) > TOLelastic){
+      Gpd[] += G2*clamp((1-sf[]), 0., 1.);
+      lambdapd[] += lambda2*clamp((1-sf[]), 0., 1.);
+    }
+  }
+
+#if TREE
+  sf.prolongation = fraction_refine;
+  sf.dirty = true; // boundary conditions need to be updated
+#endif
+}


### PR DESCRIPTION
## Description
This pull request introduces a series of improvements and updates to the viscoelastic scalar 2D implementation:

1. **Documentation Update**: The file metadata and deprecation notice have been updated to reflect the latest version of the `log-conform-viscoelastic-scalar-2D` file. Users are now directed to use the current version, `log-conform-viscoelastic-scalar-2D`, instead.

2. **Refactoring and Alignment**: The `log-conform-viscoelastic-scalar-2D.h` file has been refactored to add detailed documentation and align it with the structure and content of the 3D counterpart, `log-conform-viscoelastic-scalar-3D.h`. Additionally, some under-the-hood changes have been made to improve the code's robustness and maintainability.

3. **Viscoelastic Fluid Support**: Support for viscoelastic fluids has been added to the two-phase flow simulation. This includes the introduction of new scalar fields (`Gpd` and `lambdapd`) to store the spatially-varying elastic modulus and relaxation time, respectively, and the necessary modifications to compute these properties based on the volume fraction.

4. **Hoop Stress Bug Fix**: A bug related to the hoop stress in the viscoelastic implementation has been addressed.

5. **.gitignore Improvements**: The .gitignore file has been enhanced to better manage the project's files and directories, excluding various build-related, IDE/Editor-specific, and OS-generated files, among other improvements.

6. **Elastic Pizza Simulation**: A new version of