### PR TITLE
🧹 chore(.gitignore): Remove makefile tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@ testCases/*.ipynb
 testCases/*.py
 ## do not want to track any makefiles on remote. 
 **/*.tst
-**/make*
 **/*.s
 **/*.d*
 **/*.deps

--- a/basilisk/src/Makefile
+++ b/basilisk/src/Makefile
@@ -1,0 +1,105 @@
+CFLAGS += $(C99_FLAGS) -O2
+
+export BASILISK = $(CURDIR)
+
+# these are not Basilisk programs
+EXCLUDE = qcc.c include.c postproc.c bview.c
+
+TOPTARGETS = all clean check
+
+SUBDIRS = darcsit ast kdt wsServer gl
+
+.PHONY: subdirs $(SUBDIRS) $(TOPTARGETS)
+
+all: subdirs qcc literatec bview2D bview3D
+	@chmod +x ppm2mpeg ppm2mp4 ppm2ogv ppm2gif runtest page2html
+	@test -f xyz2kdt || ln -s kdt/xyz2kdt
+	@test -f kdtquery || ln -s kdt/kdtquery
+
+subdirs: $(SUBDIRS)
+
+$(TOPTARGETS): $(SUBDIRS)
+$(SUBDIRS):
+	$(MAKE) -C $@ $(filter-out $(SUBDIRS),$(MAKECMDGOALS))
+
+literatec:
+	cd darcsit && $(MAKE) && cd cgi-bin && $(MAKE)
+
+qcc: qcc.c include.o postproc.o ast/libast.a config
+	$(CC) $(CFLAGS) -DLIBDIR=\"`pwd`\" \
+		-DCC99="\"$(CC99)\"" \
+		-DCPP99="\"$(CPP99)\"" \
+		-DCADNACC="\"$(CADNACC)\"" \
+		-DBASILISK="\"$(BASILISK)\"" \
+		qcc.c include.o postproc.o -o qcc -Last -last -lm
+
+include.o: include.c
+	$(CC) $(CFLAGS) -DLIBDIR=\"`pwd`\" -c include.c
+
+postproc.o: postproc.c
+	$(CC) $(CFLAGS) -DLIBDIR=\"`pwd`\" -c postproc.c
+
+# uncomment the recipe below if you need to regenerate draw_get.h
+# and draw_json.h
+
+# draw_get.h: draw.h params.awk
+#	awk -f params.awk < draw.h > draw_get.h
+
+# Uncomment the recipes below if you need to re-generate include.c or
+# postproc.c
+
+# include.c: include.lex
+#	flex -P inc -o include.c include.lex
+
+# postproc.c: postproc.lex
+#	flex -P post -o postproc.c postproc.lex
+
+bview2D: qcc bview.c draw_get.h display.h view.h draw.h khash.h
+	./qcc $(CFLAGS) -autolink bview.c -o bview2D -lfb_tiny -lm
+
+bview3D: qcc bview.c draw_get.h display.h view.h draw.h khash.h
+	./qcc $(CFLAGS) -autolink -grid=octree bview.c -o bview3D -lfb_tiny -lm
+
+alltags:
+	cd navier-stokes && $(MAKE) tags
+	cd layered && $(MAKE) tags
+	cd ehd && $(MAKE) tags
+	cd compressible && $(MAKE) tags
+	cd examples && $(MAKE) tags
+	cd test && $(MAKE) tags
+	$(MAKE) tags
+	cd navier-stokes && $(MAKE) itags
+	cd layered && $(MAKE) itags
+	cd compressible && $(MAKE) itags
+	cd ehd && $(MAKE) itags
+	cd examples && $(MAKE) itags
+	cd test && $(MAKE) itags
+	$(MAKE) itags
+
+etags:
+	etags *.h grid/*.h
+
+checklinks:
+	$(LINKCHECKER) 	$(BASILISK_URL)/src/README 		\
+			$(BASILISK_URL)/src/test/README 	\
+			$(BASILISK_URL)/src/examples/README | 	\
+		tee checklinks.log
+
+checklinksfast:
+	wget --spider -nd -nv -r \
+		--reject-regex '.*[?]changes=.*' \
+		--reject-regex '.*[?]history' \
+		$(BASILISK_URL) 2>&1 | \
+		grep -v ^unlink: | tee checklinks.log
+
+changelog:
+	darcs changes > ChangeLog
+
+dist:
+	darcs dist
+
+diff:
+	cd .. && tar czvf src/diff.tgz `darcs whatsnew -s | \
+		sed 's/. .\/.*\/$$//g' | awk '{print $$2}'`
+
+include $(BASILISK)/Makefile.defs

--- a/basilisk/src/ast/Makefile
+++ b/basilisk/src/ast/Makefile
@@ -1,0 +1,81 @@
+CFLAGS += -I.. -DBASILISK=\"$(subst /ast,,$(CURDIR))\"
+
+OBJECTS = ast.o tokens.o basilisk.o translate.o allocator.o \
+	faststack.o stencil.o types.o references.o kernels.o check.o interpreter/interpreter.o
+
+TOPTARGETS = all clean check
+
+SUBDIRS = interpreter
+
+.PHONY: subdirs $(SUBDIRS) $(TOPTARGETS)
+
+all: subdirs libast.a
+
+subdirs: $(SUBDIRS)
+
+$(TOPTARGETS): $(SUBDIRS)
+$(SUBDIRS):
+	$(MAKE) -C $@ $(filter-out $(SUBDIRS),$(MAKECMDGOALS))
+
+libast.a: $(OBJECTS)
+	ar cr $@ $(OBJECTS)
+
+# Uncomment the recipe below if you need to re-generate basilisk.c
+
+# basilisk.c: basilisk.yacc
+# 	bison -Dparse.trace -d -o basilisk.c basilisk.yacc
+# 	sed -i 's/^ *YY_REDUCE_PRINT *(yyn);/ YY_REDUCE_PRINT (yyn); DEFAULT_ACTION (yyn);/' basilisk.c
+
+symbols.h: basilisk.c Makefile
+	echo "// Automatically generated from basilisk.yacc" > symbols.h
+	@echo 'const char * symbol_name (int sym);' >> symbols.h
+	@echo 'int token_symbol (int token);' >> symbols.h
+	@awk '/^enum yysymbol_kind_t/{a=1}{if(a)print $$0;}/};/{a=0}' \
+		basilisk.c | sed 's/YYSYMBOL_/sym_/g' >> symbols.h
+
+grammar.h: basilisk.yacc grammar
+	./grammar < basilisk.yacc  > grammar.h
+
+grammar: grammar.c
+	$(CC) $(CFLAGS) grammar.c -o grammar
+
+# Uncomment the recipe below if you need to re-generate tokens.c
+
+# tokens.c: tokens.lex
+#	flex -o tokens.c tokens.lex
+
+basilisk.o: ast.h parser.h
+
+ast.o: ast.h parser.h symbols.h
+
+stack.o: stack.h
+
+faststack.o: stack.h symbols.h ast.h
+
+tokens.o: ast.h basilisk.c
+
+translate.o: ast.h symbols.h einstein_sum.h
+
+stencil.o: ast.h symbols.h
+
+allocator.o: allocator.h
+
+check.o: ast.h symbols.h grammar.h
+
+expr.o: ast.h symbols.h
+
+types.o: ast.h symbols.h
+
+references.o: ast.h symbols.h
+
+kernels.o: ast.h symbols.h
+
+clean:
+	rm -f *.o *.a
+
+qcc: qcc.c libast.a
+	$(CC) $(CFLAGS) -o $@ $^
+
+expr: expr.c ast.h libast.a
+	$(CC) $(CFLAGS) -o $@ $< -L. -last -lm
+

--- a/basilisk/src/ast/interpreter/Makefile
+++ b/basilisk/src/ast/interpreter/Makefile
@@ -1,0 +1,40 @@
+BASILISK=$(subst /ast/interpreter,,$(CURDIR))
+CFLAGS += -I../.. -I.. -DBASILISK=\"$(BASILISK)\"
+QCC = ../../qcc
+
+interpreter.o: dimension.c graph.c ../ast.h ../symbols.h
+
+check: $(subst .c,.tst,$(wildcard test*.c)) \
+	test15.vtst test16.vtst test20.vtst \
+	$(subst .c,.dtst,$(wildcard dimension-tests/test*.c))
+
+refs:
+	for f in test*.c; do 						\
+		$(QCC) $(FLAGS) -source -run=1 $$f 2>&1 | 		\
+                sed "s|$(BASILISK)||g" > `echo $$f | sed 's/\.c/.ref/'`; \
+	done
+
+drefs:
+	for f in dimension-tests/test*.c; do 				\
+		$(QCC) $(FLAGS) -source -dimensions -run=1 $$f 2>&1 | 	\
+                sed "s|$(BASILISK)||g" > `echo $$f | sed 's/\.c/.ref/'`; \
+	done
+
+%.tst: %.c %.ref $(QCC) declarations.h  internal.h  overload.h
+	$(QCC) $(FLAGS) -source -run=1 $< 2>&1 | sed "s|$(BASILISK)||g" > $@
+	-rm -f _$<
+	diff $@ $*.ref || (rm -f $@ && exit 1)
+
+%.dtst: %.c %.ref $(QCC) declarations.h  internal.h  overload.h
+	$(QCC) $(FLAGS) -source -dimensions -run=1 $< 2>&1 | sed "s|$(BASILISK)||g" > $@
+	diff $@ $*.ref || (rm -f $@ && exit 1)
+
+%.vtst: %.c %.ref $(QCC) declarations.h  internal.h  overload.h
+	valgrind -q $(QCC) $(FLAGS) -source -run=1 $< 2>&1 | sed "s|$(BASILISK)||g" > $@
+	-rm -f _$<
+	diff $@ $*.ref || (rm -f $@ && exit 1)
+
+clean:
+	rm -f *.o *.a *.*tst dimension-tests/*.*tst
+
+dimension-tests/test20.dtst: FLAGS += -non-finite

--- a/basilisk/src/compressible/Makefile
+++ b/basilisk/src/compressible/Makefile
@@ -1,0 +1,1 @@
+include $(BASILISK)/Makefile.defs

--- a/basilisk/src/cvmix/Makefile
+++ b/basilisk/src/cvmix/Makefile
@@ -1,0 +1,42 @@
+# where is CVMIX?
+ifeq ($(CVMIX),)
+	CVMIX = $(HOME)/local/src/CVMix-src
+endif
+
+# how to compile?
+ifeq ($(F90),)
+	F90 := gfortran
+endif
+ifeq ($(FCFLAGS),)
+	FCFLAGS := -Wall -O2
+endif
+
+# This should be completed as new objects are added to CVMix
+HEADERS = kinds_and_types.h 	\
+          background.h 		\
+          convection.h 		\
+          ddiff.h 		\
+          kpp.h 		\
+          math.h 		\
+          put_get.h 		\
+          shear.h 		\
+          tidal.h 		\
+          utils.h
+
+OBJECTS = $(subst .h,.o,$(HEADERS))
+
+libcvmixc.a: $(CVMIX)/lib/libcvmix.a $(HEADERS) common.o $(OBJECTS)
+	cp -f $(CVMIX)/lib/libcvmix.a libcvmixc.a
+	ar -rs libcvmixc.a common.o $(OBJECTS)
+	objcopy --globalize-symbol=__cvmix_kpp_MOD_compute_phi_inv libcvmixc.a
+
+%.h: $(CVMIX)/src/shared/cvmix_%.F90 comments.awk cvmix.awk
+	( tr '[:upper:]' '[:lower:]' < $< | awk -f comments.awk \
+	| awk -f cvmix.awk -vbase=$* -v sourcefile="$<" > $@ ) || \
+	( rm -f $*.F90 && exit 1 )
+
+%.o: %.F90
+	$(F90) $(FCFLAGS) -I$(CVMIX)/include -c $<
+
+clean:
+	rm -f *.o $(HEADERS)

--- a/basilisk/src/darcsit/Makefile
+++ b/basilisk/src/darcsit/Makefile
@@ -1,0 +1,26 @@
+all: literate-c codeblock pagemagic sanitize urldecode
+
+CFLAGS += -DYY_NO_UNPUT
+
+sanitize: CFLAGS += -DYY_NO_INPUT
+
+# Uncomment the recipe below if you need to re-generate codeblock.c,
+# sanitize.c or literate-c.c
+
+# add flex -d below for debugging
+# %.c: %.lex Makefile cleanstatic.awk
+# 	flex $<
+# 	@sed -e 's/^[ \t]*int \(yy[a-z_]*[ \t]*(\)/static int \1/g' \
+# 	    -e 's/^[ \t]*YY_BUFFER_STATE \(yy[a-z_]*[ \t]*(\)/static YY_BUFFER_STATE \1/g' \
+# 	    -e 's/^[ \t]*YY_EXTRA_TYPE \(yy[a-z_]*[ \t]*(\)/static YY_EXTRA_TYPE \1/g' \
+# 	    -e 's/^[ \t]*FILE \*\(yy[a-z_]*[ \t]*(\)/static FILE \*\1/g' \
+# 	    -e 's/^[ \t]*char \*\(yy[a-z_]*[ \t]*(\)/static char \*\1/g' \
+# 	    -e 's/^[ \t]*void \*\(yy[a-z_]*[ \t]*(\)/static void \*\1/g' \
+# 	    -e 's/extern int yylex/static int yylex/g' \
+#           -e 's/^[ \t]*void \(yy[a-z_]*[ \t]*(\)/static void \1/g' < lex.yy.c | \
+#		awk -v file="$<" -f cleanstatic.awk > $@
+
+clean:
+	rm -f literate-c codeblock pagemagic sanitize urldecode
+
+check:

--- a/basilisk/src/darcsit/cgi-bin/Makefile
+++ b/basilisk/src/darcsit/cgi-bin/Makefile
@@ -1,0 +1,4 @@
+# -*-Makefile-*-
+
+all:
+	chmod 755 darcsit

--- a/basilisk/src/darcsit/templates/Makefile
+++ b/basilisk/src/darcsit/templates/Makefile
@@ -1,0 +1,9 @@
+TEMPLATES=$(BASILISK)/darcsit/templates/
+
+all: page.static edit.static
+
+%.static: *.st $(TEMPLATES)includes.awk
+	awk -v path=$(TEMPLATES) -f $(TEMPLATES)includes.awk $*.st | \
+	awk -v path=$(TEMPLATES) -f $(TEMPLATES)includes.awk | \
+	awk -v path=$(TEMPLATES) -f $(TEMPLATES)includes.awk | \
+	sed 's/\\\$$/__ESCAPEDDOLLAR__/g' > $@

--- a/basilisk/src/ehd/Makefile
+++ b/basilisk/src/ehd/Makefile
@@ -1,0 +1,1 @@
+include $(BASILISK)/Makefile.defs

--- a/basilisk/src/examples/Makefile
+++ b/basilisk/src/examples/Makefile
@@ -1,0 +1,38 @@
+include ../Makefile.defs
+
+# the default CFLAGS are set in $(BASILISK)/config
+CFLAGS += -O2 -fopenmp
+
+all: check
+
+madsen-sv.c: madsen.c
+	ln -s madsen.c madsen-sv.c 
+madsen-sv.tst: madsen.s
+madsen-sv.tst: CFLAGS += -DSAINT_VENANT=1
+
+madsen.tst: madsen-sv.tst
+
+tohoku-gn.c: tohoku.c
+	ln -s tohoku.c tohoku-gn.c 
+tohoku-gn.tst: tohoku.s
+tohoku-gn.tst: CFLAGS += -DGN=1
+
+tohoku-hydro.c: tohoku.c
+	ln -s tohoku.c tohoku-hydro.c 
+tohoku-hydro.tst: tohoku.s
+tohoku-hydro.tst: CFLAGS += -DHYDRO=1
+
+shoal-ml.c: shoal.c
+	ln -s shoal.c shoal-ml.c 
+shoal-ml.tst: shoal.s
+shoal-ml.tst: CFLAGS += -DML=1
+
+gulf-stream.tst: CC = mpicc -D_MPI=8
+
+# Coupled solvers
+
+master.s: slave.o
+
+slave.o: $(QCC) slave.c ../slave.h Makefile
+	$(QCC) $(CFLAGS) -fno-common -D_OBJECT -c slave.c
+	objcopy -G slave_step -G slave_stop -G slave_interpolate slave.o

--- a/basilisk/src/gl/Makefile
+++ b/basilisk/src/gl/Makefile
@@ -1,0 +1,47 @@
+CFLAGS += -I..
+
+.PHONY: tinyrenderer all clean
+
+all: tinyrenderer libglutils.a libfb_tiny.a
+
+clean: tinyrenderer
+tinyrenderer:
+	$(MAKE) -C $@ $(filter-out tinyrenderer,$(MAKECMDGOALS))
+
+libglutils.a: trackball.o utils.o polygonize.o \
+		og_stroke_mono_roman.o parser.o TinyPngOut.o
+	ar cr $@ $^
+
+utils.o: utils.h
+
+# Uncomment the recipe below if you need to re-generate parser.tab.c
+
+# parser.tab.c: parser.y
+#	bison parser.y
+
+parser: parser.tab.c parser.h
+	$(CC) $(CFLAGS) -DSTANDALONE=1 -o parser parser.tab.c -lm
+
+parser.o: parser.tab.c parser.h
+	$(CC) $(CFLAGS) -c -o parser.o parser.tab.c
+
+clean:
+	rm -f *.o *.a
+
+libfb_tiny.a: fb_tiny.o tinyrenderer/tiny.o
+	ar cr $@ $^
+
+tinyrenderer/tiny.o:
+	cd tinyrenderer && $(MAKE)
+
+fb_tiny.o: tinygl.h tinyrenderer/tiny.h tinyrenderer/geometry.h 
+
+## These libraries depend on OpenGL and are not built by default
+
+libfb_osmesa.a: fb_osmesa.o
+	ar cr $@ $^
+
+libfb_glx.a: fb_glx.o OffscreenContextGLX.o fbo.o
+	ar cr $@ $^
+
+check:

--- a/basilisk/src/gl/tinyrenderer/Makefile
+++ b/basilisk/src/gl/tinyrenderer/Makefile
@@ -1,0 +1,17 @@
+tiny.o: tiny.c tiny.h geometry.h ../framebuffer.h
+	$(CC) $(CFLAGS) -c tiny.c
+
+# An example of usage, requires the models in
+# https://github.com/ssloy/tinyrenderer/tree/master/obj
+#
+# make main
+# ./main obj/diablo3_pose/diablo3_pose.obj
+
+OBJS = model.cpp tgaimage.cpp main.cpp
+HDS = geometry.h  model.h  tiny.h tgaimage.h
+
+main: $(OBJS) tiny.o $(HDS)
+	g++ $(CFLAGS) $(OBJS) tiny.o -o main
+
+clean:
+	rm -f tiny.o main

--- a/basilisk/src/gotm/Makefile
+++ b/basilisk/src/gotm/Makefile
@@ -1,0 +1,28 @@
+# where is the GOTM source code?
+ifeq ($(GOTM),)
+	GOTM = $(HOME)/local/src/GOTM
+endif
+
+# matching directories in the GOTM source code $GOTM/src/
+DIRS = airsea gotm input meanflow observations turbulence util
+
+all:
+	for d in $(DIRS); do ( cd $$d && make -f ../Makefile headers ) done
+
+MODULE = $(notdir $(PWD))
+
+HEADERS = $(subst $(GOTM)/src/$(MODULE)/,,	\
+	$(subst .F90,.h,$(shell ls $(GOTM)/src/$(MODULE)/*.F90)))
+
+headers: $(HEADERS)
+
+%.h: $(GOTM)/src/$(MODULE)/%.F90 ../comments.awk ../gotm.awk
+	@echo "extracting $@ from $<"
+	@( tr '[:upper:]' '[:lower:]' < $< | awk -f ../comments.awk 	\
+	| awk -f ../gotm.awk -vbase=$* -v sourcefile="$<" 		\
+		-v dirname=$(MODULE) > $@ ) || 				\
+	( rm -f $*.F90 && exit 1 )
+
+dependencies.svg: comments.awk dependencies.awk
+	cat `find $(GOTM)/src -name '*.F90'` | awk -f comments.awk | \
+	awk -f dependencies.awk | unflatten | dot -Tsvg > dependencies.svg

--- a/basilisk/src/grid/gpu/Makefile
+++ b/basilisk/src/grid/gpu/Makefile
@@ -1,0 +1,20 @@
+.PHONY: all clean
+
+CFLAGS += -I.. -O2
+
+all: libgpu.a
+
+# uncomment if errors.lex is modified
+# errors.c: errors.lex
+#	flex -P gpu_errors -o errors.c errors.lex
+
+libgpu.a: errors.o glad.o
+	ar cr libgpu.a errors.o glad.o
+
+check:
+
+Benchmarks/plots: Benchmarks/advection Benchmarks/bump2D-gpu Benchmarks/advection.awk \
+	Benchmarks/lid Benchmarks/reversed Benchmarks/turbulence
+Benchmarks.md.html: Benchmarks/plots
+
+include ../../Makefile.defs

--- a/basilisk/src/kdt/Makefile
+++ b/basilisk/src/kdt/Makefile
@@ -1,0 +1,21 @@
+# if you want to use a memory-buffered KDT, add -DBUFFERED_KDT=1 to CFLAGS
+CFLAGS += -O2
+
+all: libkdt.a xyz2kdt kdtquery
+
+libkdt.a: kdt.o
+	ar cr libkdt.a kdt.o
+
+kdt.o: kdt.c
+	$(CC) $(CFLAGS) -D_FILE_OFFSET_BITS=64 -c kdt.c
+
+xyz2kdt: xyz2kdt.c kdt.o kdt.h
+	$(CC) $(CFLAGS) xyz2kdt.c kdt.o -o xyz2kdt -lm
+
+kdtquery: kdtquery.c kdt.o kdt.h
+	$(CC) $(CFLAGS) kdtquery.c kdt.o -o kdtquery -lm
+
+clean:
+	rm -f *.o
+
+check:

--- a/basilisk/src/layered/Makefile
+++ b/basilisk/src/layered/Makefile
@@ -1,0 +1,1 @@
+include $(BASILISK)/Makefile.defs

--- a/basilisk/src/navier-stokes/Makefile
+++ b/basilisk/src/navier-stokes/Makefile
@@ -1,0 +1,1 @@
+include $(BASILISK)/Makefile.defs

--- a/basilisk/src/ppr/Makefile
+++ b/basilisk/src/ppr/Makefile
@@ -1,0 +1,10 @@
+CFLAGS = -O3
+
+libppr.a: ppr_1d.o ppr.o
+	ar cr libppr.a $^
+
+%.o: %.f90 *.f90
+	gfortran -cpp $(CFLAGS) -c $<
+
+clean:
+	rm -f *.o *.a

--- a/basilisk/src/test/Makefile
+++ b/basilisk/src/test/Makefile
@@ -1,0 +1,584 @@
+all: check 3D-tests mpi-tests load-balancing curvature-tests	\
+	axi-tests cadna-tests embed-tests multilayer-tests	\
+	multilayer-stratified gotm-tests dimensions-tests
+
+failed:
+	$(MAKE) -k `find . -name fail | sed -e 's|\./||g' -e 's|/fail|.tst|g'`
+
+# the default CFLAGS are set in ../config
+CFLAGS += -O2 -DMTRACE=3
+
+# list only non-default tests
+check: halo.vtst interpolate.vtst events.vtst faces.vtst coarsen.vtst \
+	lid-restore.tst poiseuille.vtst tag.ctst
+
+# these tests have special dependencies/compilation requirements
+
+basilisk.tst: basilisk.gnu
+basilisk.tst: CFLAGS += -DDEBUG=1
+
+boundaries3.tst: boundaries3.ctst
+
+bubble-spherical.c: bubble.c
+	ln -sf bubble.c bubble-spherical.c 
+bubble-spherical.s: CFLAGS += -grid=multigrid1D -DSPHERICAL=1
+bubble-spherical.tst: CFLAGS += -grid=multigrid1D -DSPHERICAL=1
+
+collapse-inviscid.c: collapse.c
+	ln -sf collapse.c collapse-inviscid.c 
+collapse-inviscid.s: CFLAGS += -DINVISCID=1 
+collapse-inviscid.tst: CFLAGS += -DINVISCID=1
+
+collapse-spherical.c: collapse.c
+	ln -sf collapse.c collapse-spherical.c 
+collapse-spherical.s: CFLAGS += -grid=multigrid1D -DSPHERICAL=1
+collapse-spherical.tst: CFLAGS += -grid=multigrid1D -DSPHERICAL=1
+
+collapse.tst: collapse-spherical.tst collapse-inviscid.tst
+
+dry-explicit.c: dry.c
+	ln -sf dry.c dry-explicit.c 
+dry-explicit.s: CFLAGS += -DEXPLICIT=1 
+dry-explicit.tst: CFLAGS += -DEXPLICIT=1
+
+dry.tst: dry-explicit.tst
+
+drybump-explicit.c: drybump.c
+	ln -sf drybump.c drybump-explicit.c 
+drybump-explicit.s: CFLAGS += -DEXPLICIT=1
+drybump-explicit.tst: CFLAGS += -DEXPLICIT=1
+
+drybump.tst: drybump-explicit.tst
+
+drybump2D-implicit.c: drybump2D.c
+	ln -sf drybump2D.c drybump2D-implicit.c 
+drybump2D-implicit.s: CFLAGS += -DIMPLICIT=1
+drybump2D-implicit.tst: CFLAGS += -DIMPLICIT=1
+
+drybump2D.tst: drybump2D-implicit.tst
+
+lake-tr.tst: lake-tr-explicit.tst lake-tr-ml.tst
+
+lake-tr-explicit.c: lake-tr.c
+	ln -sf lake-tr.c lake-tr-explicit.c
+lake-tr-explicit.s: CFLAGS += -DEXPLICIT=1
+lake-tr-explicit.tst: CFLAGS += -DEXPLICIT=1
+
+lake-tr-ml.c: lake-tr.c
+	ln -sf lake-tr.c lake-tr-ml.c
+lake-tr-ml.s: CFLAGS += -DML=1
+lake-tr-ml.tst: CFLAGS += -DML=1
+
+multiriverinflow.tst: multiriverinflow.ctst
+multiriverinflow.tst: CFLAGS += -fopenmp
+multiriverinflow.ctst: CFLAGS += -fopenmp
+
+parabola-explicit.c: parabola.c
+	ln -sf parabola.c parabola-explicit.c 
+parabola-explicit.s: CFLAGS += -DEXPLICIT=1
+parabola-explicit.tst: CFLAGS += -DEXPLICIT=1
+
+parabola.tst: parabola-explicit.tst parabola-ml.tst
+
+seawallsv.c: seawall.c
+	ln -sf seawall.c seawallsv.c 
+seawallsv.s: CFLAGS += -DSAINT_VENANT=1
+seawallsv.tst: CFLAGS += -DSAINT_VENANT=1
+
+seawall.tst: seawallsv.tst seawall-ml.tst
+
+conicalsv.c: conical.c
+	ln -sf conical.c conicalsv.c 
+conicalsv.s: CFLAGS += -DSAINT_VENANT=1
+conicalsv.tst: CFLAGS += -DSAINT_VENANT=1
+
+conical-implicit.c: conical.c
+	ln -sf conical.c conical-implicit.c 
+conical-implicit.s: CFLAGS += -DSAINT_VENANT=1 -DIMPLICIT=1
+conical-implicit.tst: CFLAGS += -DSAINT_VENANT=1 -DIMPLICIT=1
+
+conical.tst: conicalsv.tst conical-implicit.tst conical-ml.tst
+
+curvature.tst: curvature.3D.tst
+
+explicit.c: implicit.c
+	ln -sf implicit.c explicit.c 
+explicit.s: CFLAGS += -DEXPLICIT=1
+explicit.tst: CFLAGS += -DEXPLICIT=1
+
+explicit-ml.c: implicit.c
+	ln -sf implicit.c explicit-ml.c 
+explicit-ml.s: CFLAGS += -DML=1 -DEXPLICIT=1
+explicit-ml.tst: CFLAGS += -DML=1 -DEXPLICIT=1
+
+implicit-ml.c: implicit.c
+	ln -sf implicit.c implicit-ml.c 
+implicit-ml.s: CFLAGS += -DML=1
+implicit-ml.tst: CFLAGS += -DML=1
+
+implicit.tst: explicit.tst explicit-ml.tst implicit-ml.tst
+
+bore.tst: bore1.tst
+
+explosion3D.tst: CFLAGS=-grid=multigrid3D
+
+explosion3D.c: explosion.c
+	ln -sf explosion.c explosion3D.c
+
+explosion.tst: explosion.ctst explosion.3D.tst explosion3D.tst
+
+laplacian.tst: laplacian.ctst
+
+lidmac.c: lid.c
+	ln -sf lid.c lidmac.c
+lidmac.s: CFLAGS += -DMAC=1
+lidmac.s.d: CFLAGS += -DMAC=1
+lidmac.tst: CFLAGS += -DMAC=1
+
+lid.tst: lidmac.tst
+
+lid-restore.c: lid.c
+	ln -sf lid.c lid-restore.c
+lid-restore.dump: lid/dump
+	ln -sf lid/dump lid-restore.dump
+lid-restore.tst: lid.tst lid-restore.dump
+
+oscillation-compressible.c: oscillation.c
+	ln -sf oscillation.c oscillation-compressible.c 
+oscillation-compressible.s: CFLAGS += -DCOMPRESSIBLE=1
+oscillation-compressible.tst: CFLAGS += -DCOMPRESSIBLE=1
+
+oscillation-momentum.c: oscillation.c
+	ln -sf oscillation.c oscillation-momentum.c 
+oscillation-momentum.s: CFLAGS += -DMOMENTUM=1
+oscillation-momentum.tst: CFLAGS += -DMOMENTUM=1
+
+oscillation.tst: oscillation-momentum.tst oscillation-compressible.tst
+
+ponds-implicit.c: ponds.c
+	ln -sf ponds.c ponds-implicit.c
+ponds-implicit.s: CFLAGS += -DIMPLICIT=1
+ponds-implicit.tst: CFLAGS += -DIMPLICIT=1
+
+ponds.tst: ponds-implicit.tst
+
+poiseuille-fenep.c: poiseuille-oldroydb.c
+	ln -sf poiseuille-oldroydb.c poiseuille-fenep.c
+poiseuille-fenep.s: CFLAGS += -DFENE_P=1
+poiseuille-fenep.tst: CFLAGS += -DFENE_P=1
+
+poiseuille-oldroydb.tst: poiseuille-fenep.tst
+
+poisson.tst: poisson.ctst
+
+rising-axi.c: rising.c
+	ln -sf rising.c rising-axi.c
+rising-axi.s: CFLAGS += -DAXIS=1
+rising-axi.tst: CFLAGS += -DAXIS=1
+
+rising-axi-momentum.c: rising.c
+	ln -sf rising.c rising-axi-momentum.c
+rising-axi-momentum.s: CFLAGS += -DAXIS=1 -DMOMENTUM=1
+rising-axi-momentum.tst: CFLAGS += -DAXIS=1 -DMOMENTUM=1
+
+rising-axi-clsvof.c: rising.c
+	ln -sf rising.c rising-axi-clsvof.c
+rising-axi-clsvof.s: CFLAGS += -DAXIS=1 -DLEVELSET=1 -DCLSVOF=1
+rising-axi-clsvof.tst: CFLAGS += -DAXIS=1 -DLEVELSET=1 -DCLSVOF=1
+
+rising2.c: rising.c
+	ln -sf rising.c rising2.c
+rising2.s: CFLAGS += -DCASE2=1
+rising2.tst: CFLAGS += -DCASE2=1
+
+rising2-levelset.c: rising.c
+	ln -sf rising.c rising2-levelset.c
+rising2-levelset.s: CFLAGS += -DCASE2=1 -DLEVELSET=1
+rising2-levelset.tst: CFLAGS += -DCASE2=1 -DLEVELSET=1
+
+rising2-clsvof.c: rising.c
+	ln -sf rising.c rising2-clsvof.c
+rising2-clsvof.s: CFLAGS += -DCASE2=1 -DLEVELSET=1 -DCLSVOF=1
+rising2-clsvof.tst: CFLAGS += -DCASE2=1 -DLEVELSET=1 -DCLSVOF=1
+
+rising-reduced.c: rising.c
+	ln -sf rising.c rising-reduced.c
+rising-reduced.s: CFLAGS += -DREDUCED=1
+rising-reduced.tst: CFLAGS += -DREDUCED=1
+
+rising-levelset.c: rising.c
+	ln -sf rising.c rising-levelset.c
+rising-levelset.s: CFLAGS += -DLEVELSET=1
+rising-levelset.tst: CFLAGS += -DLEVELSET=1
+
+rising-clsvof.c: rising.c
+	ln -sf rising.c rising-clsvof.c
+rising-clsvof.s: CFLAGS += -DLEVELSET=1 -DCLSVOF=1
+rising-clsvof.tst: CFLAGS += -DLEVELSET=1 -DCLSVOF=1
+
+reversed.tst: reversed.ctst
+
+rotate.tst: rotate.ctst
+
+rt-reduced.c: rt.c
+	ln -sf rt.c rt-reduced.c
+rt-reduced.s: CFLAGS += -DREDUCED=1
+rt-reduced.tst: CFLAGS += -DREDUCED=1
+
+taylor-green-all-mach.c: taylor-green.c
+	ln -sf taylor-green.c taylor-green-all-mach.c 
+taylor-green-all-mach.s: CFLAGS += -DALL_MACH=1
+taylor-green-all-mach.tst: CFLAGS += -DALL_MACH=1
+
+taylor-green.tst: taylor-green-all-mach.tst
+
+view.tst: CC = mpicc -D_MPI=4
+view.tst: view.3D.tst
+
+view.3D.tst: CC = mpicc -D_MPI=4
+
+coarsen.vtst: CFLAGS = -DMTRACE=3 -progress
+
+# Axisymmetric tests
+
+axi-tests: axiadvection.tst axi.tst poiseuille-axi.tst \
+	rising-axi.tst rising-axi-momentum.tst
+
+# 3D tests
+
+3D-tests: circle.3D.tst curvature.3D.tst hf.3D.tst periodic.3D.tst \
+	poisson.3D.tst refineu.3D.tst solenoidal.3D.tst
+
+# Curvature tests
+
+curvature-tests: hf.tst hf3D.tst hf.ctst hf.3D.tst hf1.tst hf-mask.tst \
+	curvature.tst curvature.3D.tst
+
+hf-mask.tst: CFLAGS += -DTRASH=1
+
+# Multilayer tests
+
+multilayer-tests: dispersion-gn.tst dispersion.tst \
+	beach-ml.tst seawall-ml.tst conical-ml.tst \
+	bar-ml.tst parabola-ml.tst lonlat-ml.tst \
+	wind-driven-nh.tst wind-driven.tst large.tst \
+	gaussian-stvt.tst gaussian-hydro.tst gaussian.tst \
+	stokes-ns.tst stokes.tst ponds-ml.tst \
+	galilean_invariance.tst \
+	stommel-ml.tst explicit-ml.tst implicit-ml.tst lake-tr-ml.tst \
+	geo.tst nonlinear-ml.tst tsunami.tst
+
+multilayer-stratified: horn.tst lock.tst overflow.tst kh.tst
+
+overflow.tst: overflow-isopycnal.tst
+
+overflow-isopycnal.c: overflow.c
+	ln -sf overflow.c overflow-isopycnal.c 
+overflow-isopycnal.s: CFLAGS += -DISOPYCNAL=1
+overflow-isopycnal.tst: CFLAGS += -DISOPYCNAL=1
+
+kh.tst: kh-ns.tst kh-hydro.tst
+
+kh-ns.tst: CC = mpicc -D_MPI=8
+
+kh-hydro.c: kh.c
+	ln -sf kh.c kh-hydro.c 
+kh-hydro.s: CFLAGS += -DHYDRO=1
+kh-hydro.tst: CFLAGS += -DHYDRO=1
+
+dispersion-gn.c: dispersion.c
+	ln -sf dispersion.c dispersion-gn.c 
+dispersion-gn.tst: dispersion-gn.s
+
+dispersion.tst: CFLAGS += -DML=1
+
+bar-ml.c: bar.c
+	ln -sf bar.c bar-ml.c 
+bar-ml.s: CFLAGS += -DML=1
+bar-ml.tst: CFLAGS += -DML=1
+
+wind-driven-nh.c: wind-driven.c
+	ln -sf wind-driven.c wind-driven-nh.c 
+wind-driven-nh.s: CFLAGS += -DML=1 -DNH=1
+wind-driven-nh.tst: CFLAGS += -DML=1 -DNH=1
+
+wind-driven-stvt.c: wind-driven.c
+	ln -sf wind-driven.c wind-driven-stvt.c 
+
+wind-driven.s: CFLAGS += -DML=1
+wind-driven.tst: CFLAGS += -DML=1
+
+large.tst: large-ns.tst
+
+gaussian-hydro.c: gaussian.c
+	ln -sf gaussian.c gaussian-hydro.c 
+gaussian-hydro.s: CFLAGS += -DML=1 -DHYDRO=1
+gaussian-hydro.tst: CFLAGS += -DML=1 -DHYDRO=1
+
+gaussian-nometric.c: gaussian.c
+	ln -sf gaussian.c gaussian-nometric.c 
+gaussian-nometric.s: CFLAGS += -DML=1 -DNOMETRIC=1
+gaussian-nometric.tst: CFLAGS += -DML=1 -DNOMETRIC=1
+
+gaussian-stvt.c: gaussian.c
+	ln -sf gaussian.c gaussian-stvt.c 
+gaussian-stvt.tst: gaussian-stvt.s
+
+gaussian.s: CFLAGS += -DML=1
+gaussian.tst: CFLAGS += -DML=1
+
+parabola-ml.c: parabola.c
+	ln -sf parabola.c parabola-ml.c 
+parabola-ml.s: CFLAGS += -DML=1
+parabola-ml.tst: CFLAGS += -DML=1
+
+seawall-ml.c: seawall.c
+	ln -sf seawall.c seawall-ml.c 
+seawall-ml.s: CFLAGS += -DML=1
+seawall-ml.tst: CFLAGS += -DML=1
+
+beach-ml.c: beach.c
+	ln -sf beach.c beach-ml.c 
+beach-ml.s: CFLAGS += -DML=1
+beach-ml.tst: CFLAGS += -DML=1
+
+conical-ml.c: conical.c
+	ln -sf conical.c conical-ml.c 
+conical-ml.s: CFLAGS += -DML=1
+conical-ml.tst: CFLAGS += -DML=1
+
+lonlat-ml.c: lonlat.c
+	ln -sf lonlat.c lonlat-ml.c 
+lonlat-ml.s: CFLAGS += -DML=1
+lonlat-ml.tst: CFLAGS += -DML=1
+
+ponds-ml.c: ponds.c
+	ln -sf ponds.c ponds-ml.c 
+ponds-ml.tst: ponds.s
+
+ponds-ml.tst: CFLAGS += -DML=1
+
+stommel-ml.tst: CFLAGS += -DML=1
+
+nonlinear.tst: nonlinear-ml.tst
+
+nonlinear-ml.c: nonlinear.c
+	ln -sf nonlinear.c nonlinear-ml.c 
+nonlinear-ml.s: CFLAGS += -DML=1
+nonlinear-ml.tst: CFLAGS += -DML=1
+
+shockwave.tst: CFLAGS += -grid=bitree
+shockwave.ctst: CFLAGS += -grid=multigrid1D
+shockwave.tst: shockwave.ctst
+
+shrinking-axi.c: shrinking.c
+	ln -sf shrinking.c shrinking-axi.c 
+shrinking-axi.s: CFLAGS += -DAXIS=1 -grid=quadtree
+shrinking-axi.tst: CFLAGS += -DAXIS=1 -grid=quadtree
+
+shrinking.s: CFLAGS += -grid=multigrid1D
+shrinking.tst: CFLAGS += -grid=multigrid1D
+shrinking.tst: shrinking-axi.tst
+
+## MPI tests
+
+# bump2Dp.tst crashes with -DDEBUGCOND=1 but works with -DDEBUGCOND=0
+
+mpi-tests: indexing.tst indexing.3D.tst \
+	mpi-restriction.tst mpi-restriction.3D.tst \
+	mpi-reduce.tst openmp-reduce.tst \
+	mpi-refine.tst mpi-refine1.tst mpi-refine.3D.tst \
+	mpi-laplacian.tst mpi-laplacian.3D.tst \
+	mpi-circle.tst mpi-circle1.tst mpi-flux.tst \
+	mpi-interpu.tst mpi-coarsen.tst mpi-coarsen1.tst \
+	hf1.tst pdump.tst restore.tst \
+	pdump-multigrid.tst restore-multigrid.tst \
+	restore-tree.tst \
+	poiseuille-periodic.tst \
+	gfsi.tst gfs.tst \
+	load-balancing \
+	mpi-grid.tst mpi-periodic-3D.tst \
+	source.tst tag.tst tag1.tst view.tst view.3D.tst \
+	boundary_vertex.tst boundary_vertex3D.tst \
+	foreach_bnd1.tst vertices-bc.tst
+
+indexing.tst:		CC = mpicc -D_MPI=3
+indexing.3D.tst:	CC = mpicc -D_MPI=3
+mpi-restriction.tst:	CC = mpicc -D_MPI=3
+mpi-restriction.3D.tst:	CC = mpicc -D_MPI=3
+mpi-reduce.tst:		CC = mpicc -D_MPI=3
+
+openmp-reduce.c: mpi-reduce.c
+	ln -sf mpi-reduce.c openmp-reduce.c
+openmp-reduce.s: CFLAGS += -fopenmp
+openmp-reduce.tst: CFLAGS += -fopenmp
+
+mpi-refine.tst:		CC = mpicc -D_MPI=4
+mpi-refine1.tst:	CC = mpicc -D_MPI=11
+mpi-refine.3D.tst:	CC = mpicc -D_MPI=4
+mpi-laplacian.tst:	CC = mpicc -D_MPI=3
+mpi-laplacian.3D.tst:	CC = mpicc -D_MPI=3
+mpi-circle.tst:		CC = mpicc -D_MPI=5
+foreach_bnd1.tst:	CC = mpicc -D_MPI=4
+vertices-bc.tst:	CC = mpicc -D_MPI=4
+
+mpi-circle1.c: mpi-circle.c
+	ln -sf mpi-circle.c mpi-circle1.c
+
+mpi-circle1.tst:  CC = mpicc -D_MPI=6
+mpi-flux.tst:     CC = mpicc -D_MPI=6
+mpi-interpu.tst:  CC = mpicc -D_MPI=5
+mpi-coarsen.tst:  CC = mpicc -D_MPI=2
+mpi-coarsen1.tst: CC = mpicc -D_MPI=5
+bump2Dp.tst:      CC = mpicc -D_MPI=55
+vortex.s:         CFLAGS = -DJACOBI=1
+vortex.tst:	  CC = mpicc -D_MPI=7 -DJACOBI=1
+axiadvection.s:   CFLAGS = -DJACOBI=1
+axiadvection.tst: CC = mpicc -D_MPI=7 -DJACOBI=1
+hf1.tst:	  CC = mpicc -D_MPI=7
+poiseuille-periodic.tst: CC = mpicc -D_MPI=4
+source.tst: CC = mpicc -D_MPI=7
+
+tag.tst: CC = mpicc -D_MPI=7
+tag1.tst: CC = mpicc -D_MPI=7
+
+boundary_vertex.tst: CC = mpicc -D_MPI=7
+boundary_vertex3D.tst: CC = mpicc -D_MPI=7
+
+# parallel dump()/restore()
+
+pdump.tst: CC = mpicc -D_MPI=7
+restore.dump: pdump/restore.dump
+	ln -sf pdump/restore.dump
+restore.tst: pdump.tst restore.dump
+
+pdump-multigrid.c: pdump.c
+	ln -sf pdump.c pdump-multigrid.c
+pdump-multigrid.tst: pdump.c
+pdump-multigrid.tst: CFLAGS = -grid=multigrid
+pdump-multigrid.tst: CC = mpicc -D_MPI=16
+
+restore-multigrid.dump: pdump-multigrid/restore.dump
+	ln -sf pdump-multigrid/restore.dump restore-multigrid.dump
+restore-multigrid.tst: pdump-multigrid.tst restore-multigrid.dump
+restore-multigrid.tst: CFLAGS = -grid=multigrid
+restore-multigrid.tst: CC = mpicc -D_MPI=16
+
+restore-tree.dump: pdump/restore.dump
+	ln -sf pdump/restore.dump restore-tree.dump
+restore-tree.tst: pdump.tst restore-tree.dump
+restore-tree.tst: CFLAGS = -DDEBUGCOND=false
+restore-tree.tst: CC = mpicc -D_MPI=23
+
+bump2Dp-restore.c: bump2Dp.c
+	ln -sf bump2Dp.c bump2Dp-restore.c
+bump2Dp-restore.dump: bump2Dp/dump
+	ln -sf bump2Dp/dump bump2Dp-restore.dump
+bump2Dp-restore.tst: bump2Dp.tst bump2Dp-restore.dump
+bump2Dp-restore.tst: CC = mpicc -D_MPI=15
+
+# parallel output_gfs()
+
+gfs.tst: CC = mpicc -D_MPI=7
+gfsi.gfs: gfs/gfsi.gfs
+	ln -sf gfs/gfsi.gfs
+gfsi.tst: gfs.tst gfsi.gfs
+
+# load-balancing
+
+load-balancing: balance5.tst balance6.tst balance7.tst \
+		bump2Dp.tst bump2Dp-restore.tst vortex.tst axiadvection.tst
+
+balance5.tst: CC = mpicc -D_MPI=9
+balance6.c: balance5.c
+	ln -sf balance5.c balance6.c
+balance6.tst: CC = mpicc -D_MPI=17
+balance7.tst: CC = mpicc -D_MPI=17
+
+# MPI-parallel multigrid
+
+mpi-grid.tst: CC = mpicc -D_MPI=4
+mpi-periodic-3D.c: periodic.c
+	ln -sf periodic.c mpi-periodic-3D.c
+mpi-periodic-3D.tst: CC = mpicc -D_MPI=8
+mpi-periodic-3D.tst: CFLAGS += -grid=multigrid3D
+
+# CADNA tests
+# These are ignored for the moment since nobody seems to be
+# interested and this is complicated to maintain and expensive to run
+
+cadna-tests: # poiseuille.CADNA.tst sag.CADNA.tst poisson.CADNA.tst
+
+# Periodic boundary tests
+
+periodic1.tst: CFLAGS += -grid=bitree -DTRASH=1
+periodic2.c: periodic1.c
+	ln -sf periodic1.c periodic2.c
+periodic2.tst: CFLAGS += -DTRASH=1
+periodic3.c: periodic1.c
+	ln -sf periodic1.c periodic3.c
+periodic3.tst: CFLAGS += -grid=octree -DTRASH=1
+
+# Embedded boundary tests
+
+dirichlet.tst: CFLAGS += -DDIRICHLET=1
+dirichlet.c: neumann.c
+	ln -sf neumann.c dirichlet.c
+
+dirichlet-axi.c: neumann-axi.c
+	ln -sf neumann-axi.c dirichlet-axi.c
+dirichlet-axi.s: CFLAGS += -DDIRICHLET=1
+dirichlet-axi.tst: CFLAGS += -DDIRICHLET=1
+
+dirichlet3D.tst: CFLAGS += -DDIRICHLET=1
+dirichlet3D.c: neumann3D.c
+	ln -sf neumann3D.c dirichlet3D.c
+
+hydrostatic2.tst: CC = mpicc -D_MPI=8
+
+embed-tests: neumann.tst dirichlet.tst poiseuille45.tst \
+	couette.tst wannier.tst hydrostatic2.tst cylinders.tst \
+	porous.tst porous1.tst uf.tst starting.tst \
+	neumann3D.tst dirichlet3D.tst hydrostatic3.tst spheres.tst \
+        neumann-axi.tst dirichlet-axi.tst
+
+# General Ocean Turbulence Model (GOTM) tests
+
+gotm-tests: couette-gotm.tst entrainment.tst ows_papa.tst
+
+ows_papa-kpp.c: ows_papa.c
+	ln -sf ows_papa.c ows_papa-kpp.c 
+ows_papa-kpp.s: CFLAGS += -DKPP=1
+ows_papa-kpp.tst: CFLAGS += -DKPP=1
+
+ows_papa.tst: ows_papa-kpp.tst
+
+# Stencils
+
+stencils.tst: CFLAGS += -DPRINTBOUNDARY=1
+
+# CLSVOF
+
+capwave-clsvof.c: capwave.c
+	ln -sf capwave.c capwave-clsvof.c 
+capwave-clsvof.s: CFLAGS += -DCLSVOF=1
+capwave-clsvof.tst: CFLAGS += -DCLSVOF=1
+
+# Dimensions
+
+dimensions-tests: bump2D.s capwave.s lid.s rising-axi.s		\
+	rising-reduced.s vortex.s sessile.s large.s lock.s	\
+	wind-driven-stvt.s shock.s starting.s layered.s 	\
+	stokes.s stokes-ns.s lonlat.s overflow.s bleck.s
+
+# GPUs
+# fixme: the dependencies *.gpu.s.d are not created automatically
+gpu-tests: gpu.gpu.tst gpu-cpu.gpu.tst gpu-reduce.gpu.tst layers.gpu.tst nonlinear.gpu.tst \
+	advection.gpu.tst bump2D-gpu.tst reversed.gpu.tst axi.gpu.tst lid.gpu.tst
+gpu-tests: CFLAGS += -DPRINTNSHADERS
+
+gpu-cpu.c: gpu.c
+	ln -sf gpu.c gpu-cpu.c
+gpu-cpu.gpu.tst: CFLAGS += -cpu
+
+include ../Makefile.defs

--- a/basilisk/src/wsServer/Makefile
+++ b/basilisk/src/wsServer/Makefile
@@ -1,0 +1,83 @@
+# Copyright (C) 2016-2020 Davidson Francis <davidsondfgl@gmail.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>
+
+AR        = ar
+INCLUDE   = $(CURDIR)/include
+SRC       = $(CURDIR)/src
+CFLAGS   +=  -O2
+CFLAGS   +=  -I $(INCLUDE)
+ARFLAGS   =  cr
+LIB       =  libws.a
+MCSS_DIR ?= /usr/bin/
+MANPAGES  = $(CURDIR)/doc/man/man3
+AFL_FUZZ ?= no
+
+# Prefix
+ifeq ($(PREFIX),)
+    PREFIX := /usr/local
+endif
+
+# Detect machine type
+MACHINE := $(shell uname -m)
+ifeq ($(MACHINE), x86_64)
+	LIBDIR = $(PREFIX)/lib64
+else
+	LIBDIR = $(PREFIX)/lib
+endif
+
+# Check if AFL fuzzing enabled
+ifeq ($(AFL_FUZZ), yes)
+    CC = afl-gcc
+    CFLAGS := $(filter-out -O2,$(CFLAGS))
+    CFLAGS += -DVERBOSE_MODE -DAFL_FUZZ -g
+    $(info [+] AFL Fuzzing build enabled)
+endif
+
+# Source
+C_SRC = $(wildcard $(SRC)/base64/*.c)    \
+		$(wildcard $(SRC)/handshake/*.c) \
+		$(wildcard $(SRC)/sha1/*.c)      \
+		$(wildcard $(SRC)/*.c)
+
+OBJ = $(C_SRC:.c=.o)
+
+# Conflicts
+.PHONY: doc
+.PHONY: tests
+
+# Paths
+INCDIR = $(PREFIX)/include
+BINDIR = $(PREFIX)/bin
+
+# General objects
+%.o: %.c
+	$(CC99) $< $(CFLAGS) -c -o $@
+
+# All
+all: libws.a
+
+# Library
+libws.a: $(OBJ)
+	$(AR) $(ARFLAGS) $(LIB) $^
+
+# Clean
+clean:
+	@rm -f $(SRC)/base64/*.o
+	@rm -f $(SRC)/handshake/*.o
+	@rm -f $(SRC)/sha1/*.o
+	@rm -f $(SRC)/*.o
+	@rm -f $(LIB)
+
+check:

--- a/testCases/Makefile
+++ b/testCases/Makefile
@@ -1,0 +1,3 @@
+CFLAGS += -O2 -disable-dimensions
+
+include ../basilisk/src/Makefile.defs


### PR DESCRIPTION
This commit updates the .gitignore file to exclude makefiles from being tracked in the repository. The line `**/make*` has been removed, ensuring that makefiles are no longer ignored. This change helps streamline the tracking of relevant files in the project.
